### PR TITLE
vitasdk-update: Add a script to update an existing vitasdk installation

### DIFF
--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -1,51 +1,19 @@
 #!/bin/sh
 set -e
 
-get_download_link () {
-  curl "https://api.github.com/repos/vitasdk/autobuilds/releases" | grep "browser_download_url" | grep $1 | head -n 1 | cut -d '"' -f 4
-}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 INSTALLDIR="/usr/local/vitasdk"
+
+. $DIR/include/install-vitasdk.sh
 
 if [ -d "$INSTALLDIR" ]; then
   echo "$INSTALLDIR already exists. Remove it first (e.g. 'sudo rm -rf $INSTALLDIR' or 'rm -rf $INSTALLDIR') and then restart this script"
   exit 1
 fi
 
-case "$(uname -s)" in
-   Darwin*)
-    mkdir -p $INSTALLDIR
-    wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link osx)"
-    tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
-   ;;
-
-   Linux*)
-    if [ -n "${TRAVIS}" ]; then
-        sudo apt-get install libc6-i386 lib32stdc++6 lib32gcc1 patch
-    fi
-    sudo mkdir -p $INSTALLDIR
-    sudo chown $USER:$(id -gn $USER) $INSTALLDIR
-    wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link linux)"
-    tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
-   ;;
-
-   MSYS*|MINGW64*)
-    UNIX=false
-    mkdir -p $INSTALLDIR
-    wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link mingw32)"
-    tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
-   ;;
-
-   CYGWIN*|MINGW32*)
-    echo "Please use msys2. Exiting..."
-    exit 1
-   ;;
-
-   *)
-     echo "Unknown OS"
-     exit 1
-    ;;
-esac
+echo "==> Installing vitasdk to $INSTALLDIR"
+install_vitasdk $INSTALLDIR
 
 echo "Please add the following to the bottom of your .bashrc:"
 printf "\033[0;36m"'export VITASDK=/usr/local/vitasdk'"\033[0m\n"

--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+b() {
+	$DIR/../vdpm $1
+}
+
+install_packages() {
+	b zlib
+	b bzip2
+	b libzip
+	b libpng
+	b libexif
+	b libjpeg-turbo
+	b jansson
+	b yaml-cpp
+	b freetype
+	b harfbuzz
+	b fftw
+	b libvita2d
+	b libmad
+	b libogg
+	b libvorbis
+	b libtremor
+	b libftpvita
+	b henkaku
+	b taihen
+	b libk
+	b libdebugnet
+	b onigmo
+	b sdl
+	b sdl_image
+	b sdl_mixer
+	b sdl_net
+	b sdl_ttf
+	b sdl2
+	b sdl2_image
+	b sdl2_mixer
+	b sdl2_net
+	b sdl2_ttf
+	b openssl
+	b curl
+	b expat
+	b opus
+	b unrar
+	b glm
+	b libxml2
+	b speexdsp
+	b pixman
+	b TinyGL
+	b kuio
+	b taipool
+	b mpg123
+	b soloud
+	b quirc
+	b Box2D
+	b libsndfile
+}

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+get_download_link () {
+  curl "https://api.github.com/repos/vitasdk/autobuilds/releases" | grep "master" | grep "browser_download_url" | grep $1 | head -n 1 | cut -d '"' -f 4
+}
+
+install_vitasdk () {
+  INSTALLDIR=$1
+
+  case "$(uname -s)" in
+     Darwin*)
+      mkdir -p $INSTALLDIR
+      wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link osx)"
+      tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+     ;;
+
+     Linux*)
+      if [ -n "${TRAVIS}" ]; then
+          sudo apt-get install libc6-i386 lib32stdc++6 lib32gcc1 patch
+      fi
+      if [ ! -d "$INSTALLDIR" ]; then
+        sudo mkdir -p $INSTALLDIR
+        sudo chown $USER:$(id -gn $USER) $INSTALLDIR
+      fi
+      wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link linux)"
+      tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+     ;;
+
+     MSYS*|MINGW64*)
+      UNIX=false
+      mkdir -p $INSTALLDIR
+      wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link mingw32)"
+      tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+     ;;
+
+     CYGWIN*|MINGW32*)
+      echo "Please use msys2. Exiting..."
+      exit 1
+     ;;
+
+     *)
+       echo "Unknown OS"
+       exit 1
+      ;;
+  esac
+
+}

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -12,6 +12,7 @@ install_vitasdk () {
       mkdir -p $INSTALLDIR
       wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link osx)"
       tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+      rm -f "vitasdk-nightly.tar.bz2"
      ;;
 
      Linux*)
@@ -24,6 +25,7 @@ install_vitasdk () {
       fi
       wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link linux)"
       tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+      rm -f "vitasdk-nightly.tar.bz2"
      ;;
 
      MSYS*|MINGW64*)
@@ -31,6 +33,7 @@ install_vitasdk () {
       mkdir -p $INSTALLDIR
       wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link mingw32)"
       tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1
+      rm -f "vitasdk-nightly.tar.bz2"
      ;;
 
      CYGWIN*|MINGW32*)

--- a/install-all.sh
+++ b/install-all.sh
@@ -4,6 +4,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-. include/install-packages.sh
+. $DIR/include/install-packages.sh
 
 install_packages

--- a/install-all.sh
+++ b/install-all.sh
@@ -2,56 +2,8 @@
 
 set -e
 
-b() {
-	./vdpm $1
-}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-b zlib
-b bzip2
-b libzip
-b libpng
-b libexif
-b libjpeg-turbo
-b jansson
-b yaml-cpp
-b freetype
-b harfbuzz
-b fftw
-b libvita2d
-b libmad
-b libogg
-b libvorbis
-b libtremor
-b libftpvita
-b henkaku
-b taihen
-b libk
-b libdebugnet
-b onigmo
-b sdl
-b sdl_image
-b sdl_mixer
-b sdl_net
-b sdl_ttf
-b sdl2
-b sdl2_image
-b sdl2_mixer
-b sdl2_net
-b sdl2_ttf
-b openssl
-b curl
-b expat
-b opus
-b unrar
-b glm
-b libxml2
-b speexdsp
-b pixman
-b TinyGL
-b kuio
-b taipool
-b mpg123
-b soloud
-b quirc
-b Box2D
-b libsndfile
+. include/install-packages.sh
+
+install_packages

--- a/vitasdk-update
+++ b/vitasdk-update
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+if [ -z "$VITASDK" ]; then
+  echo '$VITASDK is not set'
+  exit 1
+fi
+
+. $DIR/include/install-vitasdk.sh
+. $DIR/include/install-packages.sh
+
+echo "==> Updating vitasdk"
+install_vitasdk $VITASDK
+
+echo "==> Updating packages"
+install_packages
+
+echo "All done!"


### PR DESCRIPTION
This is to be installed into vitasdk by buildscripts.

The installation flow remains compatible (bootstrap-vitasdk, then install-all)
but now the user can run vitasdk-update to update the SDK and packages.