### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian
+RUN apt-get update
+RUN apt-get install -y git cmake sudo wget curl bzip2 xz-utils build-essential
+COPY . /vdpm
+WORKDIR /vdpm
+RUN bash ./bootstrap-vitasdk.sh
+RUN echo "export VITASDK=/usr/local/vitasdk" >> /root/.bashrc \
+ && echo "export PATH=/usr/local/vitasdk/bin:$PATH" >> /root/.bashrc
+ENV VITASDK /usr/local/vitasdk
+ENV PATH /usr/local/vitasdk/bin:$PATH
+RUN bash ./install-all.sh


### PR DESCRIPTION
I wanted to mess around a bit but didnt find any ready to use Docker images.

This one should always be up-to-date unless packages are deprecated or you change the way the sdk is installed. The resulting image is fairly big but contains the vitasdk and normal build tools for x86-64.

The docker image is fairly simple but can be used in multiple ways. I for example mounted some local filepaths into /projects in the container and just used it to compile projects. 