### PR TITLE
Adding support for FreeBSD and bash location discovery via env

### DIFF
--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 get_download_link () {
   curl -sL https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python - $@
@@ -8,7 +8,7 @@ install_vitasdk () {
   INSTALLDIR=$1
 
   case "$(uname -s)" in
-     Darwin*)
+     Darwin*|FreeBSD*)
       mkdir -p $INSTALLDIR
       wget -O "vitasdk-nightly.tar.bz2" "$(get_download_link master osx)"
       tar xf "vitasdk-nightly.tar.bz2" -C $INSTALLDIR --strip-components=1

--- a/install-all.sh
+++ b/install-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/vdpm
+++ b/vdpm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # vitasdk package manager
 # (aka a 5 liner around tar and curl)

--- a/vitasdk-update
+++ b/vitasdk-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
OSX is FreeBSD based, so I added FreeBSD.

Instead of assuming bash is located in /bin folder, I changed it to autodetect via env command which exists in every linux/freebsd system in /usr/bin folder. This way even if it's installed later to /usr/local/bin etc.. this will correctly find where the bash is.