### PR TITLE
Fix Typo

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -81,5 +81,5 @@ install_packages() {
 	b minizip
 	b jsoncpp
 	b lame
-	b fmmpeg
+	b ffmpeg
 }


### PR DESCRIPTION
I am not sure if the library referenced is supposed to be ffmpeg, but before I was getting this error when using "./install-all.sh"
```
Installing fmmpeg...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    593      0 --:--:-- --:--:-- --:--:--   595
xz: (stdin): File format not recognized
tar: Child returned status 1
tar: Error is not recoverable: exiting now

Failed to install, the package probably does not exist.
```
After changing to ffmpeg it the script succeeded.