### PR TITLE
add temp files to install packages script

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -4,7 +4,86 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-PACKAGES=(zlib bzip2 libzip libpng libexif libjpeg-turbo jansson yaml-cpp freetype harfbuzz fftw libvita2d libvita2d_ext libmad libogg libvorbis flac libtremor libmikmod libftpvita henkaku taihen kubridge libk libdebugnet onigmo libwebp sdl sdl_image sdl_mixer sdl_net sdl_ttf sdl_gfx sdl2 sdl2_image sdl2_mixer sdl2_net sdl2_ttf sdl2_gfx openal-soft openssl curl curlpp expat opus opusfile unrar glm libxml2 speexdsp pixman TinyGL kuio taipool mpg123 libmpeg2 soloud quirc Box2D libsndfile xz libarchive bullet libimagequant libmodplug libconfig libsodium vitaShaRK libmathneon vitaGL imgui imgui-vita2d libbaremetal minizip jsoncpp lame ffmpeg physfs)
+PACKAGES=(
+	zlib
+	bzip2
+	libzip
+	libpng
+	libexif
+	libjpeg-turbo
+	jansson
+	yaml-cpp
+	freetype
+	harfbuzz
+	fftw
+	libvita2d
+	libvita2d_ext
+	libmad
+	libogg
+	libvorbis
+	flac
+	libtremor
+	libmikmod
+	libftpvita
+	henkaku
+	taihen
+	kubridge
+	libk
+	libdebugnet
+	onigmo
+	libwebp
+	sdl
+	sdl_image
+	sdl_mixer
+	sdl_net
+	sdl_ttf
+	sdl_gfx
+	sdl2
+	sdl2_image
+	sdl2_mixer
+	sdl2_net
+	sdl2_ttf
+	sdl2_gfx
+	openal-soft
+	openssl
+	curl
+	curlpp
+	expat
+	opus
+	opusfile
+	unrar
+	glm
+	libxml2
+	speexdsp
+	pixman
+	TinyGL
+	kuio
+	taipool
+	mpg123
+	libmpeg2
+	soloud
+	quirc
+	Box2D
+	libsndfile
+	xz
+	libarchive
+	bullet
+	libimagequant
+	libmodplug
+	libconfig
+	libsodium
+	vitaShaRK
+	libmathneon
+	vitaGL
+	imgui
+	imgui-vita2d
+	libbaremetal
+	minizip
+	jsoncpp
+	lame
+	ffmpeg
+	physfs
+)
 
 b() {
 	$DIR/../vdpm $1

--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -4,87 +4,15 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+PACKAGES=(zlib bzip2 libzip libpng libexif libjpeg-turbo jansson yaml-cpp freetype harfbuzz fftw libvita2d libvita2d_ext libmad libogg libvorbis flac libtremor libmikmod libftpvita henkaku taihen kubridge libk libdebugnet onigmo libwebp sdl sdl_image sdl_mixer sdl_net sdl_ttf sdl_gfx sdl2 sdl2_image sdl2_mixer sdl2_net sdl2_ttf sdl2_gfx openal-soft openssl curl curlpp expat opus opusfile unrar glm libxml2 speexdsp pixman TinyGL kuio taipool mpg123 libmpeg2 soloud quirc Box2D libsndfile xz libarchive bullet libimagequant libmodplug libconfig libsodium vitaShaRK libmathneon vitaGL imgui imgui-vita2d libbaremetal minizip jsoncpp lame ffmpeg physfs)
+
 b() {
 	$DIR/../vdpm $1
 }
 
 install_packages() {
-	b zlib
-	b bzip2
-	b libzip
-	b libpng
-	b libexif
-	b libjpeg-turbo
-	b jansson
-	b yaml-cpp
-	b freetype
-	b harfbuzz
-	b fftw
-	b libvita2d
-	b libvita2d_ext
-	b libmad
-	b libogg
-	b libvorbis
-	b flac
-	b libtremor
-	b libmikmod
-	b libftpvita
-	b henkaku
-	b taihen
-	b kubridge
-	b libk
-	b libdebugnet
-	b onigmo
-	b libwebp
-	b sdl
-	b sdl_image
-	b sdl_mixer
-	b sdl_net
-	b sdl_ttf
-	b sdl_gfx
-	b sdl2
-	b sdl2_image
-	b sdl2_mixer
-	b sdl2_net
-	b sdl2_ttf
-	b sdl2_gfx
-	b openal-soft
-	b openssl
-	b curl
-	b curlpp
-	b expat
-	b opus
-	b opusfile
-	b unrar
-	b glm
-	b libxml2
-	b speexdsp
-	b pixman
-	b TinyGL
-	b kuio
-	b taipool
-	b mpg123
-	b libmpeg2
-	b soloud
-	b quirc
-	b Box2D
-	b libsndfile
-	b xz
-	b libarchive
-	b bullet
-	b libimagequant
-	b libmodplug
-	b libconfig
-	b libsodium
-	b vitaShaRK
-	b libmathneon
-	b vitaGL
-	b imgui
-	b imgui-vita2d
-	b libbaremetal
-	b minizip
-	b jsoncpp
-	b lame
-	b ffmpeg
-	b physfs
+	
+	for p in ${PACKAGES[@]}; do
+		b $p
+	done
 }

--- a/vdpm
+++ b/vdpm
@@ -7,31 +7,67 @@
 set -e
 set -o errtrace
 
+CLEAN=0
+
 error() {
   echo ""
   echo "Failed to install, the package probably does not exist."
   exit 1
 }
 
+write_success() {
+  touch /tmp/vdpm_install_$1
+}
+
 install_pkg() {
-  echo "Installing $1..."
-  if [ -f $1 ]; then
-    tar -C $VITASDK/arm-vita-eabi -Jxvf $1
+  if [ $CLEAN -eq 1 ]; then
+    echo "cleaning old confirmation files"
+    clean_tmp_file
   else
-    curl http://dl.vitasdk.org/$1.tar.xz | tar -C $VITASDK/arm-vita-eabi -Jxvf -
+    if [ $(find "/tmp/vdpm_install_$1" -cmin -1440 -print) ]; then
+      echo "skip install $1. Package previously installed less than one day ago"
+    else
+      echo "Installing $1..."
+      if [ -f $1 ]; then
+        tar -C $VITASDK/arm-vita-eabi -Jxvf $1
+      else
+        curl http://dl.vitasdk.org/$1.tar.xz | tar -C $VITASDK/arm-vita-eabi -Jxvf -
+        write_success $1
+      fi
+      echo "success"
+    fi
   fi
-  echo "success"
+}
+
+clean_tmp_file() {
+  rm -rf /tmp/vdpm_install_*
+}
+
+helpmenu() {
+  echo "Usage: ./vdpm package-name"
+  exit 1
 }
 
 if [ "$#" -ne 1 ]; then
-    echo "Usage: ./vdpm package-name"
-    exit 1
+  helpmenu
 fi
 
 if [ -z "$VITASDK" ]; then
   echo '$VITASDK is not set'
   exit 1
 fi
+
+while getopts "hc" opt; do
+  case ${opt} in
+    h ) helpmenu
+        exit 0
+        ;;
+    c )
+    CLEAN=1
+    shift
+    ;;
+  esac
+done
 
 trap 'error' ERR
 install_pkg $1


### PR DESCRIPTION
Hi, small change for some quality of life when downloading packages. If the current package was already downloaded by the script on the last 24 hours it won't download again. This improved the installation when the source was failing to respond to the sequential calls (probably the web server got busy)