### PR TITLE
Add Linux ARM64 support in VDPM

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -22,6 +22,7 @@ PACKAGES=(
 	libogg
 	libvorbis
 	flac
+	libtheora
 	libtremor
 	libmikmod
 	libftpvita

--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -84,6 +84,7 @@ PACKAGES=(
 	ffmpeg
 	physfs
 	vita-libdl
+	tinyxml2
 	cpython
 	pib
 )

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -4,6 +4,10 @@ get_download_link () {
   wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python - $@
 }
 
+get_download_link_arm () {
+  curl -s https://api.github.com/repos/SonicMastr/autobuilds/releases/latest | awk -F\" '/browser_download_url.*.tar.bz2/{print $(NF-1)}'
+}
+
 install_vitasdk () {
   INSTALLDIR=$1
 
@@ -22,7 +26,11 @@ install_vitasdk () {
         sudo mkdir -p $INSTALLDIR
         sudo chown $USER:$(id -gn $USER) $INSTALLDIR
       fi
-      wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
+      if ! [[ "$(uname -m)" =~ ^(armv7l|arm64|aarch64)$ ]]; then
+        wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
+      else
+        wget -O- "$(get_download_link_arm)" | tar xj -C $INSTALLDIR --strip-components=1
+      fi
      ;;
 
      MSYS*|MINGW64*)

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 get_download_link () {
-  wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python - $@
-}
-
-get_download_link_arm () {
-  curl -s https://api.github.com/repos/SonicMastr/autobuilds/releases/latest | awk -F\" '/browser_download_url.*.tar.bz2/{print $(NF-1)}'
+  if ! [[ "$(uname -m)" =~ ^(armv7l|arm64|aarch64)$ ]]; then
+    wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python - $@
+  elif [[ "$(uname -s)" == Linux* ]]; then
+    curl -s https://api.github.com/repos/SonicMastr/autobuilds/releases/latest | awk -F\" '/browser_download_url.*.tar.bz2/{print $(NF-1)}'
+  else
+    echo "Unsupported Architecture. VitaSDK not installed"
+    exit 1
+  fi
 }
 
 install_vitasdk () {
@@ -26,11 +29,7 @@ install_vitasdk () {
         sudo mkdir -p $INSTALLDIR
         sudo chown $USER:$(id -gn $USER) $INSTALLDIR
       fi
-      if ! [[ "$(uname -m)" =~ ^(armv7l|arm64|aarch64)$ ]]; then
-        wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
-      else
-        wget -O- "$(get_download_link_arm)" | tar xj -C $INSTALLDIR --strip-components=1
-      fi
+      wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
      ;;
 
      MSYS*|MINGW64*)


### PR DESCRIPTION
This adds an additional check to detected if VDPM is running on an ARM64 Linux OS and changes the VitaSDK package download to a fork of the VitaSDK toolchain that supports ARM64. Doesn't affect Linux x86_64/Windows/Mac installations