### PR TITLE
VDPM: ignore dot-files with package info

### DIFF
--- a/vdpm
+++ b/vdpm
@@ -27,7 +27,7 @@ install_pkg() {
     if [ -f $1 ]; then
       tar -C $VITASDK/arm-vita-eabi -Jxvf $1
     else
-      curl -L https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK/arm-vita-eabi -Jxvf -
+      curl -L https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK/arm-vita-eabi --exclude=\.* -Jxvf -
       write_success $1
     fi
     echo "success"


### PR DESCRIPTION
Ignore metadata added by https://github.com/vitasdk/vita-makepkg/pull/9
Merge this first.