### PR TITLE
Do not require python 3 to be called python

### DIFF
--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_download_link () {
-  wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | env python3 - $@
+  wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python3 - $@
 }
 
 install_vitasdk () {

--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_download_link () {
-  wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | python - $@
+  wget -qO- https://github.com/vitasdk/vita-headers/raw/master/.travis.d/last_built_toolchain.py | env python3 - $@
 }
 
 install_vitasdk () {


### PR DESCRIPTION
Many Linux distributions do not have a binary called python available by default and the standard way to use python in a script is using env to find a specific version of it as specified here: https://docs.python.org/3/using/unix.html#miscellaneous