### PR TITLE
Removed luajit package from install-packages.sh

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -85,7 +85,6 @@ PACKAGES=(
 	ffmpeg
 	physfs
 	vita-rss-libdl
-	luajit
 	tinyxml2
 	cpython
 	asio


### PR DESCRIPTION
Luajit was either removed or not in the release for vitasdk/packages. So running install-packages.sh was causing it to crash