### PR TITLE
Add libxmp to the list of packages to install

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -105,6 +105,7 @@ PACKAGES=(
 	SceShaccCgExt
 	boost
 	pib
+	libxmp
 )
 
 b() {


### PR DESCRIPTION
`sdl2_mixer` is built with `libxmp` support, but the `install-packages.sh` doesn't install this library. As a result, the process of building applications using `sdl2_mixer` fails.