### PR TITLE
Add libxmp-lite to install-packages.sh

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -106,6 +106,7 @@ PACKAGES=(
 	boost
 	pib
 	libxmp
+	libxmp-lite
 )
 
 b() {


### PR DESCRIPTION
This should be installed by default as SDL2_mixer will rely on it to be there.