### PR TITLE
Rework package tracking system

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -110,7 +110,7 @@ PACKAGES=(
 )
 
 b() {
-	$DIR/../vdpm $1
+	$DIR/../vdpm -f $1
 }
 
 install_packages() {

--- a/vdpm
+++ b/vdpm
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # vitadev package manager
-# (aka a 175 liner around tar and curl)
+# (aka a 179 liner around tar and curl)
 #
 
 set -e
@@ -32,7 +32,15 @@ pkg_installed() {
 
 # Get the files in a package from packages.list
 get_pkg_files() {
-  sed -n "/^PACKAGE $1$/,/^$/ { /^PACKAGE $1$/!p; }" "$PACKAGE_LIST" | sed '$d'
+  local file_list="$(sed -n "/^PACKAGE $1$/,/^$/ { /^PACKAGE $1$/!p; }" "$PACKAGE_LIST" | sed '$d')"
+  while IFS= read -r line; do
+    if [[ $line == */ ]]; then
+	sorted_list="$sorted_list"$'\n'"$line"
+    else
+        sorted_list="$line"$'\n'"$sorted_list"
+    fi
+  done <<< "$file_list"
+  echo "$sorted_list"
 }
 
 # Add an entry by name (and file list) to packages.list
@@ -47,32 +55,32 @@ remove_from_pkg_list() {
   sed -i "/^PACKAGE $1$/,/^$/d" "$PACKAGE_LIST"
 }
 
-# Loop through all files in a package and delete them. If after deleting a file that came from a package,
-# the directory is empty, delete it too. Keep going up from that until we've removed all redundant directories.
-# This sounds hazardous, but it isn't. A better solution is preferred though -- this was to get around Tar limitations, and it sucks, kind of
-remove_pkg_files() {
+# Loop through all files/folders in a package and delete them.
+# If a file/folder is wanted by another package, or a folder isn't empty, then it won't be deleted.
+remove_pkg() {
+  remove_from_pkg_list "$1"
   while read -r filepath; do
     if [[ -n $filepath ]] && [[ -w $VITASDK_ROOT/$filepath ]]; then
-      rm "$VITASDK_ROOT/$filepath"
-      local dir=$(dirname "$VITASDK_ROOT/$filepath")
-      while [[ -n "$dir" ]] && [[ -z "$(ls -A "$dir")" ]]; do
-        if [[ "$dir" = "$VITASDK_ROOT" ]]; then
-          break
-        fi
-        rm -r "$dir"
-        dir=$(dirname "$dir")
-      done
+      local operation_path="$VITASDK_ROOT/$filepath"
+
+      if grep -q "^$filepath$" "$PACKAGE_LIST"; then
+	echo "Considered removing $filepath, but it's wanted by another package"
+      elif [[ -d "$operation_path" ]] && [[ ! -z "$(ls -A "$operation_path")" ]]; then
+	echo "Considered removing $filepath, but it's not empty"
+      else
+	rm -r "$operation_path"
+      fi
     fi
-  done <<< "$1"
+  done <<< "$2"
 }
 
 # Download and extract a package to the VitaSDK "root"
 # Will return a list of all files (not directories) for package management reasons
 get_and_extract() {
   if [ -f $1 ]; then
-    tar -C $VITASDK_ROOT -Jxvf $1 | grep -v '/$'
+    tar -C $VITASDK_ROOT -Jxvf $1
   else
-    curl -sL https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK_ROOT -Jxvf - | grep -v '/$'
+    curl -sL https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK_ROOT -Jxvf -
   fi
 }
 
@@ -83,8 +91,7 @@ uninstall_pkg() {
   else
     echo "Uninstalling $1..."
     local files="$(get_pkg_files "$1")"
-    remove_pkg_files "$files"
-    remove_from_pkg_list "$1"
+    remove_pkg "$1" "$files"
     echo "Successfully uninstalled $1."
   fi
 }
@@ -97,16 +104,13 @@ install_pkg() {
       echo "Use the -f flag to reinstall it/install anyways."
       return 0
     else
-      remove_pkg_files "$(get_pkg_files "$1")"
-      remove_from_pkg_list "$1"
+      remove_pkg "$1" "$(get_pkg_files "$1")"
     fi
   fi
 
   echo "Installing $1..."
-
-  files=$(get_and_extract $1)
+  local files="$(get_and_extract $1)"
   append_to_pkg_list "$1" "$files"
-
   echo "Successfully installed $1"
 }
 

--- a/vdpm
+++ b/vdpm
@@ -1,45 +1,128 @@
 #!/bin/bash
 #
-# vitasdk package manager
-# (aka a 5 liner around tar and curl)
+# vitadev package manager
+# (aka a 175 liner around tar and curl)
 #
 
 set -e
 set -o errtrace
 
 CLEAN=0
+FORCE=0
+UNINSTALL=0
 
 error() {
   echo ""
-  echo "Failed to install, the package probably does not exist."
+  echo "Operation failed. Please check the package name, and ensure you are connected to the internet."
   exit 1
 }
 
-write_success() {
-  touch /tmp/vdpm_install_$1
-}
-
-install_pkg() {
-  if [ $(find "/tmp/vdpm_install_$1" -ctime -1 -print) ]; then
-    echo "skip install $1. Package previously installed less than one day ago"
-  else
-    echo "Installing $1..."
-    if [ -f $1 ]; then
-      tar -C $VITASDK/arm-vita-eabi -Jxvf $1
-    else
-      curl -L https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK/arm-vita-eabi -Jxvf -
-      write_success $1
-    fi
-    echo "success"
+# Make sure the package list exists
+ensure_pkg_list() {
+  if [ ! -f $PACKAGE_LIST ]; then
+    mkdir -p $(dirname $PACKAGE_LIST)
+    touch $PACKAGE_LIST
   fi
 }
 
-clean_tmp_file() {
-  rm -rf /tmp/vdpm_install_*
+# Check if a package is installed
+pkg_installed() {
+  grep -q "^PACKAGE $1$" "$PACKAGE_LIST"
 }
 
+# Get the files in a package from packages.list
+get_pkg_files() {
+  sed -n "/^PACKAGE $1$/,/^$/ { /^PACKAGE $1$/!p; }" "$PACKAGE_LIST" | sed '$d'
+}
+
+# Add an entry by name (and file list) to packages.list
+append_to_pkg_list() {
+  echo "PACKAGE $1" >> "$PACKAGE_LIST"
+  echo "$2" >> "$PACKAGE_LIST"
+  echo "" >> "$PACKAGE_LIST"
+}
+
+# Remove an entry by name from packages.list
+remove_from_pkg_list() {
+  sed -i "/^PACKAGE $1$/,/^$/d" "$PACKAGE_LIST"
+}
+
+# Loop through all files in a package and delete them. If after deleting a file that came from a package,
+# the directory is empty, delete it too. Keep going up from that until we've removed all redundant directories.
+# This sounds hazardous, but it isn't. A better solution is preferred though -- this was to get around Tar limitations, and it sucks, kind of
+remove_pkg_files() {
+  while read -r filepath; do
+    if [[ -n $filepath ]] && [[ -w $VITASDK_ROOT/$filepath ]]; then
+      rm "$VITASDK_ROOT/$filepath"
+      local dir=$(dirname "$VITASDK_ROOT/$filepath")
+      while [[ -n "$dir" ]] && [[ -z "$(ls -A "$dir")" ]]; do
+        if [[ "$dir" = "$VITASDK_ROOT" ]]; then
+          break
+        fi
+        rm -r "$dir"
+        dir=$(dirname "$dir")
+      done
+    fi
+  done <<< "$1"
+}
+
+# Download and extract a package to the VitaSDK "root"
+# Will return a list of all files (not directories) for package management reasons
+get_and_extract() {
+  if [ -f $1 ]; then
+    tar -C $VITASDK_ROOT -Jxvf $1 | grep -v '/$'
+  else
+    curl -sL https://github.com/vitasdk/packages/releases/download/master/$1.tar.xz | tar -C $VITASDK_ROOT -Jxvf - | grep -v '/$'
+  fi
+}
+
+# Uninstall a package
+uninstall_pkg() {
+  if ! pkg_installed "$1"; then
+    echo "$1 is not installed or isn't in the list of installed packages"
+  else
+    echo "Uninstalling $1..."
+    local files="$(get_pkg_files "$1")"
+    remove_pkg_files "$files"
+    remove_from_pkg_list "$1"
+    echo "Successfully uninstalled $1."
+  fi
+}
+
+# Install a package
+install_pkg() {
+  if pkg_installed "$1"; then
+    if [[ $FORCE -ne 1 ]]; then
+      echo "Not installing $1; Package has already been installed."
+      echo "Use the -f flag to reinstall it/install anyways."
+      return 0
+    else
+      remove_pkg_files "$(get_pkg_files "$1")"
+      remove_from_pkg_list "$1"
+    fi
+  fi
+
+  echo "Installing $1..."
+
+  files=$(get_and_extract $1)
+  append_to_pkg_list "$1" "$files"
+
+  echo "Successfully installed $1"
+}
+
+# Clear the list of installed packages
+clear_package_list() {
+  rm -rf $PACKAGE_LIST
+}
+
+# Show usage
 helpmenu() {
-  echo "Usage: ./vdpm [-c | -h | [PACKAGES...]]"
+  echo "VitaDev Package Manager"
+  echo "Usage: ./vdpm [-c | -h | (-f|-u) [PACKAGES...]]"
+  echo "-c: Clear the package list. Only do this if you know what you're doing."
+  echo "-h: Show this help."
+  echo "-f: Forcefully install the packages. Good for reinstallations."
+  echo "-u: Uninstall the packages."
   exit 1
 }
 
@@ -52,25 +135,41 @@ if [ -z "$VITASDK" ]; then
   exit 1
 fi
 
-while getopts "hc" opt; do
+# Remove trailing slash, for good luck
+VITASDK=${VITASDK%/}
+
+VITASDK_ROOT="$VITASDK/arm-vita-eabi"
+PACKAGE_LIST="$VITASDK/etc/vdpm/packages.list"
+
+while getopts "hcfu" opt; do
   case ${opt} in
     h ) helpmenu
         exit 0
         ;;
-    c )
-    CLEAN=1
-    shift
-    ;;
+    c ) CLEAN=1
+        shift
+        ;;
+    f ) FORCE=1
+	shift
+	;;
+    u ) UNINSTALL=1
+	shift
+	;;
   esac
 done
 
 trap 'error' ERR
+ensure_pkg_list
 
 if [ $CLEAN -eq 1 ]; then
-  echo "cleaning old confirmation files"
-  clean_tmp_file
+  echo "clearing package list..."
+  clear_package_list
 else
   for p in "$@"; do
-    install_pkg "$p"
+    if [ $UNINSTALL -eq 1 ]; then
+      uninstall_pkg "$p"
+    else
+      install_pkg "$p"
+    fi
   done
 fi

--- a/vdpm
+++ b/vdpm
@@ -75,7 +75,7 @@ remove_pkg() {
 }
 
 # Download and extract a package to the VitaSDK "root"
-# Will return a list of all files (not directories) for package management reasons
+# Will return a list of all files and directories for package management reasons
 get_and_extract() {
   if [ -f $1 ]; then
     tar -C $VITASDK_ROOT -Jxvf $1


### PR DESCRIPTION
Numerous things have been changed/redone here, particularly the way that packages are tracked as being installed.
Packages are now stored in a packages.list file located in $VITASDK/etc/vdpm. This file keeps track of packages that are installed and the files that each package has placed. The /tmp-based package cache system has been removed.

Two new flags have been added; -f (force) and -u (uninstall). -f will uninstall and reinstall a package, regardless of if it's already installed. -u will simply uninstall a package.

The usage has also been modified to better reflect available arguments.

I'm submitting this for review and refactor as there is a lot of things I'm not sure about. The critical directory issues mentioned in the initial pull request have since been solved, but you can see them by viewing the original unedited pull request - it was replaced with a much better, and safer, way of handling this that I consider ready to use.

Thanks in advance.