### PR TITLE
Update install-vitasdk.sh to check for arch on Linux

### DIFF
--- a/include/install-vitasdk.sh
+++ b/include/install-vitasdk.sh
@@ -22,7 +22,13 @@ install_vitasdk () {
         sudo mkdir -p $INSTALLDIR
         sudo chown $USER:$(id -gn $USER) $INSTALLDIR
       fi
-      wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
+
+      # Check if architecture is aarch64 (ARM 64-bit)
+      if [ "$(uname -m)" == "aarch64" ]; then
+        wget -O- "$(get_download_link master linux-arm64)" | tar xj -C $INSTALLDIR --strip-components=1
+      else
+        wget -O- "$(get_download_link master linux)" | tar xj -C $INSTALLDIR --strip-components=1
+      fi
      ;;
 
      MSYS*|MINGW64*)


### PR DESCRIPTION
If aarch64 is being used, the script will atempt to download the arm64 version, otherwise it will default to x86_64 or other architectures.

FYI: I have added support for linux-arm64 (https://github.com/vitasdk/autobuilds/pull/23)