### PR TITLE
Support BSD-like sed syntax on macOS

### DIFF
--- a/vdpm
+++ b/vdpm
@@ -52,7 +52,11 @@ append_to_pkg_list() {
 
 # Remove an entry by name from packages.list
 remove_from_pkg_list() {
-  sed -i "/^PACKAGE $1$/,/^$/d" "$PACKAGE_LIST"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed "/^PACKAGE $1$/,/^$/d" "$PACKAGE_LIST"
+  else
+    sed -i "/^PACKAGE $1$/,/^$/d" "$PACKAGE_LIST"
+  fi
 }
 
 # Loop through all files/folders in a package and delete them.


### PR DESCRIPTION
On macOS, the system-wide `sed` use the `-i` flag for a different purpose:

```
SED(1)                                                         General Commands Manual

NAME
     sed – stream editor

SYNOPSIS
     sed [-EHalnru] command [-I extension] [-i extension] [file ...]
     sed [-EHalnru] [-e command] [-f command_file] [-I extension] [-i extension] [file ...]
```

this breaks the installation since the current folder (in `$PACKAGE_LIST`, that is something like `/usr/local/vitasdk`) will be interpreted as a `sed` command