### PR TITLE
Fix typo in install-packages.sh

### DIFF
--- a/include/install-packages.sh
+++ b/include/install-packages.sh
@@ -64,7 +64,7 @@ PACKAGES=(
 	libmpeg2
 	soloud
 	quirc
-	Box2D
+	box2d
 	libsndfile
 	xz
 	libarchive


### PR DESCRIPTION
Package name for Box2D should be lowercase