### PR TITLE
Install pacman off PATH, at libexec/vdpm

### DIFF
--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -269,13 +269,13 @@ case $(uname -s) in
 		pacman_binary="$staging_directory/share/vdpm/msys/usr/bin/pacman.exe"
 		;;
 	*)
-		required=(bin/vdpm bin/arm-vita-eabi-gcc bin/pacman bin/vdpm-channel \
+		required=(bin/vdpm bin/arm-vita-eabi-gcc libexec/vdpm/pacman bin/vdpm-channel \
 			bin/include/refresh-repositories.sh etc/pacman.conf version_info.txt)
-		seed_required=(bin/vdpm bin/pacman bin/vdpm-channel \
+		seed_required=(bin/vdpm libexec/vdpm/pacman bin/vdpm-channel \
 			bin/include/refresh-repositories.sh share/vdpm/channel-public-key.pem)
 		vdpm_binary="$staging_directory/bin/vdpm"
 		channel_tool=bin/vdpm-channel
-		pacman_binary="$staging_directory/bin/pacman"
+		pacman_binary="$staging_directory/libexec/vdpm/pacman"
 		;;
 esac
 (( install_from_packages )) && required=("${seed_required[@]}")
@@ -348,7 +348,7 @@ if (( install_from_packages )); then
 		--logfile "$staging_directory/var/log/pacman.log" \
 		--noconfirm --noscriptlet \
 		--sync vitasdk-core --overwrite '*/bin/vdpm*' \
-		--overwrite '*/bin/pacman*' --overwrite '*/bin/include/*' \
+		--overwrite '*/libexec/vdpm/pacman*' --overwrite '*/bin/include/*' \
 		--overwrite '*/share/vdpm/*' \
 		--overwrite '*/etc/pacman.conf'
 	mv "$staging_directory/etc/pacman.conf.selected" \

--- a/cmake/PackageClient.cmake
+++ b/cmake/PackageClient.cmake
@@ -210,9 +210,9 @@ function(vdpm_add_package_client install_dir)
         BUILD_COMMAND ${CMAKE_COMMAND} -E env
             "PKG_CONFIG_PATH=${pacman_pkg_config_path}"
             ${MESON_EXECUTABLE} compile -C <BINARY_DIR>
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/bin
-        COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/pacman ${install_dir}/bin/pacman
-        COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/pacman-conf ${install_dir}/bin/pacman-conf
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/libexec/vdpm
+        COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/pacman ${install_dir}/libexec/vdpm/pacman
+        COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/pacman-conf ${install_dir}/libexec/vdpm/pacman-conf
         COMMAND ${CMAKE_COMMAND} -E make_directory ${license_dir}
         COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/COPYING
             ${license_dir}/pacman-GPL-2.0.txt

--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -44,7 +44,7 @@ case $host in
 		;;
 	*)
 		required+=(
-			bin/vdpm bin/pacman bin/pacman-conf bin/vdpm-channel
+			bin/vdpm libexec/vdpm/pacman libexec/vdpm/pacman-conf bin/vdpm-channel
 			bin/include/host-triplet.sh bin/include/refresh-repositories.sh
 			share/vdpm/licenses/pacman-GPL-2.0.txt
 			share/vdpm/licenses/zlib.txt

--- a/scripts/validate-release-bundle.sh
+++ b/scripts/validate-release-bundle.sh
@@ -84,8 +84,11 @@ case $host in
 		fi
 		;;
 	*)
-		for executable in vdpm pacman pacman-conf vdpm-channel; do
+		for executable in vdpm vdpm-channel; do
 			test -x "$root/bin/$executable"
+		done
+		for executable in pacman pacman-conf; do
+			test -x "$root/libexec/vdpm/$executable"
 		done
 		test -x "$root/bin/include/host-triplet.sh"
 		test -x "$root/bin/include/refresh-repositories.sh"
@@ -104,7 +107,7 @@ case $host in
 		done
 		if [[ ${VDPM_VALIDATE_EXECUTABLES:-0} == 1 ]]; then
 			"$root/bin/vdpm" --help >/dev/null
-			"$root/bin/pacman" --version >/dev/null
+			"$root/libexec/vdpm/pacman" --version >/dev/null
 			"$root/bin/vdpm-channel" sha256 \
 				"$root/share/vdpm/THIRD_PARTY_NOTICES.md" >/dev/null
 		fi

--- a/src/vdpm.c
+++ b/src/vdpm.c
@@ -48,7 +48,9 @@
 #define DISCARD_ERRORS "2>/dev/null"
 #define COMMAND_OPEN ""
 #define COMMAND_CLOSE ""
-#define PACKAGE_CLIENT "bin/pacman"
+/* Kept off PATH: nothing here looks pacman up by name, and a Linux
+ * distribution's own pacman must stay reachable as plain "pacman". */
+#define PACKAGE_CLIENT "libexec/vdpm/pacman"
 #define CHANNEL_TOOL "bin/vdpm-channel"
 #endif
 

--- a/tests/gate-nightly-advances.body.sh
+++ b/tests/gate-nightly-advances.body.sh
@@ -36,7 +36,7 @@ check() {
 		failures=$((failures + 1)); fi
 }
 installed_core() {
-	pacman --config /opt/sdk/etc/pacman.conf --root /opt/sdk \
+	/opt/sdk/libexec/vdpm/pacman --config /opt/sdk/etc/pacman.conf --root /opt/sdk \
 		--dbpath /opt/sdk/var/lib/pacman --query vitasdk-core 2>/dev/null |
 		awk '{print $2}'
 }

--- a/tests/gate-series-round-trip.sh
+++ b/tests/gate-series-round-trip.sh
@@ -39,7 +39,7 @@ docker run --rm --platform linux/amd64 \
 	}
 
 	installed_core() {
-		pacman --config /opt/sdk/etc/pacman.conf --root /opt/sdk \
+		/opt/sdk/libexec/vdpm/pacman --config /opt/sdk/etc/pacman.conf --root /opt/sdk \
 			--dbpath /opt/sdk/var/lib/pacman --query vitasdk-core 2>/dev/null |
 			awk "{print \$2}"
 	}

--- a/tests/test-bootstrap-root-install.sh
+++ b/tests/test-bootstrap-root-install.sh
@@ -22,11 +22,13 @@ trap 'rm -rf -- "$temporary_directory"' EXIT
 # The same shape as the fixture in test-bootstrap.sh, with the links the real
 # SDK carries: without one the check being tested never runs.
 archive_root="$temporary_directory/archive/vitasdk"
-mkdir -p "$archive_root/bin/include" "$archive_root/etc" "$archive_root/lib"
-for program in vdpm pacman vdpm-channel arm-vita-eabi-gcc; do
+mkdir -p "$archive_root/bin/include" "$archive_root/libexec/vdpm" "$archive_root/etc" "$archive_root/lib"
+for program in vdpm vdpm-channel arm-vita-eabi-gcc; do
 	printf '#!/bin/sh\nexit 0\n' > "$archive_root/bin/$program"
 	chmod +x "$archive_root/bin/$program"
 done
+printf '#!/bin/sh\nexit 0\n' > "$archive_root/libexec/vdpm/pacman"
+chmod +x "$archive_root/libexec/vdpm/pacman"
 printf 'refresh\n' > "$archive_root/bin/include/refresh-repositories.sh"
 chmod +x "$archive_root/bin/include/refresh-repositories.sh"
 printf '[options]\nArchitecture = test vita\n' > "$archive_root/etc/pacman.conf"

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -8,11 +8,13 @@ cleanup() { rm -rf -- "$temporary_directory"; }
 trap cleanup EXIT
 
 archive_root="$temporary_directory/archive/vitasdk"
-mkdir -p "$archive_root/bin/include" "$archive_root/etc"
-for executable in pacman vdpm-channel arm-vita-eabi-gcc; do
+mkdir -p "$archive_root/bin/include" "$archive_root/libexec/vdpm" "$archive_root/etc"
+for executable in vdpm-channel arm-vita-eabi-gcc; do
 	printf '#!/usr/bin/env sh\nexit 0\n' > "$archive_root/bin/$executable"
 	chmod +x "$archive_root/bin/$executable"
 done
+printf '#!/usr/bin/env sh\nexit 0\n' > "$archive_root/libexec/vdpm/pacman"
+chmod +x "$archive_root/libexec/vdpm/pacman"
 # Records what it was asked to do, so the test can tell whether the bootstrap
 # selected the series it resolved instead of leaving the SDK on none.
 cat > "$archive_root/bin/vdpm" <<'FAKE'

--- a/tests/test-channel-refresh.sh
+++ b/tests/test-channel-refresh.sh
@@ -17,7 +17,7 @@ build=${VDPM_TEST_BUILD_DIR:-}
 root=$(mktemp -d)
 trap 'rm -rf "$root"' EXIT
 
-mkdir -p "$root/bin/include" "$root/var/lib/vdpm" "$root/etc"
+mkdir -p "$root/bin/include" "$root/libexec/vdpm" "$root/var/lib/vdpm" "$root/etc"
 printf '[options]\n' > "$root/etc/pacman.conf"
 printf '{"channel":"2026.08","sequence":1,"core":{"release":"core-1"},"packages":{"release":"packages-1"}}\n' \
 	> "$root/var/lib/vdpm/channel.json"
@@ -33,12 +33,12 @@ EOF
 chmod +x "$root/bin/include/refresh-repositories.sh"
 
 pacman_stub() {
-	cat > "$root/bin/pacman" <<EOF
+	cat > "$root/libexec/vdpm/pacman" <<EOF
 #!/bin/sh
 printf '%s\n' "\$@" > "$root/pacman-arguments"
 exit $1
 EOF
-	chmod +x "$root/bin/pacman"
+	chmod +x "$root/libexec/vdpm/pacman"
 }
 
 selected_channel() {

--- a/tests/test-channel-status.sh
+++ b/tests/test-channel-status.sh
@@ -16,13 +16,13 @@ build=${VDPM_TEST_BUILD_DIR:-}
 root=$(mktemp -d)
 trap 'rm -rf "$root"' EXIT
 
-mkdir -p "$root/bin/include" "$root/var/lib/vdpm" "$root/etc"
+mkdir -p "$root/bin/include" "$root/libexec/vdpm" "$root/var/lib/vdpm" "$root/etc"
 cp "$build/vdpm-channel" "$root/bin/"
 cp "$directory/include/list-channels.sh" "$root/bin/include/"
 chmod +x "$root/bin/include/"*.sh
 printf '[options]\n' > "$root/etc/pacman.conf"
-printf '#!/bin/sh\nexit 0\n' > "$root/bin/pacman"
-chmod +x "$root/bin/pacman"
+printf '#!/bin/sh\nexit 0\n' > "$root/libexec/vdpm/pacman"
+chmod +x "$root/libexec/vdpm/pacman"
 
 manifest()
 {
@@ -99,13 +99,13 @@ fi
 # whose move was interrupted, or that was unpacked rather than installed,
 # named a toolchain it did not carry.
 manifest 2026.09
-printf '#!/bin/sh\necho "vitasdk-core 2026.08.0-1"\n' > "$root/bin/pacman"
-chmod +x "$root/bin/pacman"
+printf '#!/bin/sh\necho "vitasdk-core 2026.08.0-1"\n' > "$root/libexec/vdpm/pacman"
+chmod +x "$root/libexec/vdpm/pacman"
 output=$(VITASDK="$root" "$build/vdpm" status 2>&1)
 check "installed core" "$output" "Installed 2026.08.0-1"
 
-printf '#!/bin/sh\nexit 1\n' > "$root/bin/pacman"
-chmod +x "$root/bin/pacman"
+printf '#!/bin/sh\nexit 1\n' > "$root/libexec/vdpm/pacman"
+chmod +x "$root/libexec/vdpm/pacman"
 output=$(VITASDK="$root" "$build/vdpm" status 2>&1)
 check "unmanaged prefix" "$output" "no registered toolchain"
 

--- a/tests/test-release-bundle.sh
+++ b/tests/test-release-bundle.sh
@@ -8,11 +8,15 @@ cleanup() { rm -rf -- "$temporary_directory"; }
 trap cleanup EXIT
 
 root="$temporary_directory/root"
-mkdir -p "$root/bin/include" "$root/share/vdpm/licenses" \
+mkdir -p "$root/bin/include" "$root/libexec/vdpm" "$root/share/vdpm/licenses" \
 	"$temporary_directory/output-one" "$temporary_directory/output-two"
-for executable in vdpm pacman pacman-conf vdpm-channel; do
+for executable in vdpm vdpm-channel; do
 	printf '#!/usr/bin/env sh\nexit 0\n' > "$root/bin/$executable"
 	chmod +x "$root/bin/$executable"
+done
+for executable in pacman pacman-conf; do
+	printf '#!/usr/bin/env sh\nexit 0\n' > "$root/libexec/vdpm/$executable"
+	chmod +x "$root/libexec/vdpm/$executable"
 done
 for helper in host-triplet.sh refresh-repositories.sh; do
 	printf '#!/usr/bin/env sh\nexit 0\n' > "$root/bin/include/$helper"

--- a/tests/test-vdpm.sh
+++ b/tests/test-vdpm.sh
@@ -13,13 +13,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$sdk_root/bin/include" "$sdk_root/etc"
-cat > "$sdk_root/bin/pacman" <<'EOF'
+mkdir -p "$sdk_root/bin/include" "$sdk_root/libexec/vdpm" "$sdk_root/etc"
+cat > "$sdk_root/libexec/vdpm/pacman" <<'EOF'
 #!/usr/bin/env bash
 printf '%q ' "$@" >> "$VDPM_TEST_LOG"
 printf '\n' >> "$VDPM_TEST_LOG"
 EOF
-chmod +x "$sdk_root/bin/pacman"
+chmod +x "$sdk_root/libexec/vdpm/pacman"
 cat > "$sdk_root/bin/include/refresh-repositories.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'refresh %s\n' "$1" >> "$VDPM_TEST_LOG"


### PR DESCRIPTION
# vdpm — Install pacman off PATH, at libexec/vdpm

## What does this change?

Moves the bundled `pacman` and `pacman-conf` from `bin/` to `libexec/vdpm/`. Updates the CMake install step, the `PACKAGE_CLIENT` macro in `src/vdpm.c`, `bootstrap-vitasdk.sh`, the release-bundle scripts, and every test that stubs a fake `pacman`.

## Why is this change needed?

Fixes #119. `bootstrap-vitasdk.sh` prepends `$VITASDK/bin` to `PATH`, and `pacman` lived there, so the SDK's own pacman shadowed a Linux distribution's real one for anything that invoked it by name — `paru` included, per the report. Nothing in vdpm needs it on `PATH`: it's always invoked by an absolute path built from the install root, never looked up by name.

## Testing

Ran locally: `tests/test-vdpm.sh`, `tests/test-channel-status.sh`, `tests/test-channel-refresh.sh`, `tests/test-release-bundle.sh`, `tests/test-bootstrap.sh` — all pass. Also updated `tests/gate-series-round-trip.sh` and `tests/gate-nightly-advances.body.sh`, which run a real bootstrap inside a container and query the installed core through bare `pacman` on `PATH` — exactly the pattern this fix removes — but couldn't run those two locally (they need Docker plus a real published release to bootstrap against).

## Compatibility

Changes the release-bundle and bootstrap-archive file layout. Anything that consumes a specific vdpm release and expects `bin/pacman` needs a matching update — see the companion PR in `vitasdk/buildscripts`.

## Third-party material

None.

## AI assistance
- Claude Sonnet 5

## Additional context

Companion PR: `vitasdk/buildscripts`#next-vdpm-libexec-pacman (buildscripts' packaging scripts hardcode the same old path in five places). That branch can't merge until a vdpm release carrying this fix exists and `VDPM_TAG` is bumped to it.
