### PR TITLE
host-triplet: detect musl, FreeBSD and Cygwin hosts (gated on the publishing chain)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
       - tests/test-bootstrap-root-install.sh
       - tests/test-bootstrap-seed.sh
       - tests/test-bootstrap-windows.ps1
+      - tests/test-host-triplet.sh
       - tests/test-release-bundle.sh
       - .github/workflows/release.yml
   push:
@@ -70,6 +71,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
+      - name: Exercise the host triplet contract
+        if: matrix.host == 'x86_64-linux-gnu'
+        shell: bash
+        run: ./tests/test-host-triplet.sh
       - name: Exercise the Windows installer under PowerShell
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,4 +84,6 @@ if(BUILD_TESTING AND UNIX)
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-channel-names.sh")
     add_test(NAME vdpm-bootstrap-contract
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-bootstrap.sh")
+    add_test(NAME vdpm-host-triplet-contract
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-host-triplet.sh")
 endif()

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -88,14 +88,18 @@ detect_host_triplet() {
 	case $(uname -s) in
 		Darwin*) printf '%s-apple-darwin\n' "$architecture" ;;
 		Linux*)
-			if ldd --version 2>&1 | grep -qi musl; then
+			# Not a pipeline: musl's ldd exits 1, which pipefail reads as glibc.
+			local banner
+			banner=$(ldd --version 2>&1 || :)
+			if [[ $banner == *musl* ]] ||
+				[[ -z $banner && -e /lib/ld-musl-$architecture.so.1 ]]; then
 				printf '%s-linux-musl\n' "$architecture"
 			else
 				printf '%s-linux-gnu\n' "$architecture"
 			fi
 			;;
 		FreeBSD*) printf '%s-unknown-freebsd\n' "$architecture" ;;
-		MSYS*|MINGW*|CYGWIN*) printf '%s-w64-mingw32\n' "$architecture" ;;
+		MSYS*|MINGW64*|CYGWIN*) printf '%s-w64-mingw32\n' "$architecture" ;;
 		*) return 1 ;;
 	esac
 }

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -78,7 +78,7 @@ detect_host_triplet() {
 	case $architecture in
 		amd64) architecture=x86_64 ;;
 		arm64|aarch64)
-			if [[ $(uname -s) == Linux ]]; then
+			if [[ $(uname -s) == Linux || $(uname -s) == FreeBSD ]]; then
 				architecture=aarch64
 			else
 				architecture=arm64
@@ -87,7 +87,14 @@ detect_host_triplet() {
 	esac
 	case $(uname -s) in
 		Darwin*) printf '%s-apple-darwin\n' "$architecture" ;;
-		Linux*) printf '%s-linux-gnu\n' "$architecture" ;;
+		Linux*)
+			if ldd --version 2>&1 | grep -qi musl; then
+				printf '%s-linux-musl\n' "$architecture"
+			else
+				printf '%s-linux-gnu\n' "$architecture"
+			fi
+			;;
+		FreeBSD*) printf '%s-unknown-freebsd\n' "$architecture" ;;
 		MSYS*|MINGW*|CYGWIN*) printf '%s-w64-mingw32\n' "$architecture" ;;
 		*) return 1 ;;
 	esac

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -158,14 +158,25 @@ if [[ -z $local_archive && ( -z $url || -z $expected_sha256 ) ]]; then
 			fi
 		else
 			url="https://github.com/vitasdk/vdpm/releases/download/$SEED_RELEASE/vdpm-$SEED_VERSION-$host.tar.bz2"
+			seed_url_generated=1
 		fi
 	fi
 
 	if [[ -z $expected_sha256 ]]; then
+		command -v curl >/dev/null || command -v wget >/dev/null || {
+			printf 'curl or wget is required to bootstrap VitaSDK\n' >&2
+			exit 1
+		}
 		sidecar_content=$(download_to_string "${url}.sha256" || true)
 		if [[ -n $sidecar_content ]]; then
 			expected_sha256=$(printf '%s' "$sidecar_content" | awk '{print $1}')
 		fi
+	fi
+
+	if [[ -z $expected_sha256 && -n ${seed_url_generated:-} ]]; then
+		printf 'no bootstrap seed is published for %s at %s\n' "$host" "$SEED_RELEASE" >&2
+		printf 'set VITASDK_SEED_ARCHIVE to a locally built bundle to proceed\n' >&2
+		exit 1
 	fi
 fi
 

--- a/include/host-triplet.sh
+++ b/include/host-triplet.sh
@@ -10,14 +10,18 @@ vdpm_host_triplet() {
 	case $(uname -s) in
 		Darwin*) printf '%s-apple-darwin\n' "$architecture" ;;
 		Linux*)
-			if ldd --version 2>&1 | grep -qi musl; then
+			# Not a pipeline: musl's ldd exits 1, which pipefail reads as glibc.
+			local banner
+			banner=$(ldd --version 2>&1 || :)
+			if [[ $banner == *musl* ]] ||
+				[[ -z $banner && -e /lib/ld-musl-$architecture.so.1 ]]; then
 				printf '%s-linux-musl\n' "$architecture"
 			else
 				printf '%s-linux-gnu\n' "$architecture"
 			fi
 			;;
 		FreeBSD*) printf '%s-unknown-freebsd\n' "$architecture" ;;
-		MSYS*|MINGW64*) printf '%s-w64-mingw32\n' "$architecture" ;;
+		MSYS*|MINGW64*|CYGWIN*) printf '%s-w64-mingw32\n' "$architecture" ;;
 		*) return 1 ;;
 	esac
 }

--- a/include/host-triplet.sh
+++ b/include/host-triplet.sh
@@ -5,11 +5,18 @@ vdpm_host_triplet() {
 	architecture=$(uname -m)
 	case $architecture in
 		amd64) architecture=x86_64 ;;
-		arm64) [[ $(uname -s) == Linux ]] && architecture=aarch64 ;;
+		arm64) [[ $(uname -s) == Linux || $(uname -s) == FreeBSD ]] && architecture=aarch64 ;;
 	esac
 	case $(uname -s) in
 		Darwin*) printf '%s-apple-darwin\n' "$architecture" ;;
-		Linux*) printf '%s-linux-gnu\n' "$architecture" ;;
+		Linux*)
+			if ldd --version 2>&1 | grep -qi musl; then
+				printf '%s-linux-musl\n' "$architecture"
+			else
+				printf '%s-linux-gnu\n' "$architecture"
+			fi
+			;;
+		FreeBSD*) printf '%s-unknown-freebsd\n' "$architecture" ;;
 		MSYS*|MINGW64*) printf '%s-w64-mingw32\n' "$architecture" ;;
 		*) return 1 ;;
 	esac

--- a/tests/test-channel-manifest.sh
+++ b/tests/test-channel-manifest.sh
@@ -11,13 +11,11 @@ set -euo pipefail
 
 repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-manifest.XXXXXXXX")
-host=$(uname -m)
-[[ $host == arm64 && $(uname -s) == Linux ]] && host=aarch64
-case $(uname -s) in
-	Darwin*) host="$host-apple-darwin" ;;
-	Linux*) host="$host-linux-gnu" ;;
-	*) printf 'unsupported test host\n' >&2; exit 1 ;;
-esac
+source "$repository_root/include/host-triplet.sh"
+host=$(vdpm_host_triplet) || {
+	printf 'unsupported test host\n' >&2
+	exit 1
+}
 
 cleanup() { rm -rf -- "$temporary_root"; }
 trap cleanup EXIT

--- a/tests/test-host-triplet.sh
+++ b/tests/test-host-triplet.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# The bootstrap script and the installed vdpm frontend each carry their own
-# copy of this detection, and both have to agree with what release.yml
-# actually publishes: linux-gnu vs. linux-musl only differ by libc, glibc
-# ceiling has no effect on the triplet, and FreeBSD's `uname -m` reports
-# "arm64" the same way Darwin does, so it has to be told apart by `uname -s`.
+# Both copies of the host detection must agree, and with what release.yml publishes.
 
 set -euo pipefail
 
@@ -11,8 +7,8 @@ directory=$(cd "$(dirname "$0")/.." && pwd -P)
 fixtures=$(mktemp -d)
 trap 'rm -rf "$fixtures"' EXIT
 
-# A fake uname/ldd pair placed ahead of the real ones on PATH, so the
-# detection functions run for real but see whichever host is under test.
+# A fake uname/ldd pair placed ahead of the real ones on PATH; the musl stub
+# mirrors real musl ldd, which prints to stderr and exits 1.
 stub_host() {
 	local kernel=$1 machine=$2 libc=${3:-}
 	local bin="$fixtures/bin"
@@ -27,7 +23,7 @@ esac
 EOF
 	chmod +x "$bin/uname"
 	if [[ $libc == musl ]]; then
-		printf '#!/bin/sh\necho "musl libc (%s)"\n' "$machine" > "$bin/ldd"
+		printf '#!/bin/sh\necho "musl libc (%s)" >&2\nexit 1\n' "$machine" > "$bin/ldd"
 	else
 		printf '#!/bin/sh\necho "ldd (GNU libc) 2.39"\n' > "$bin/ldd"
 	fi
@@ -55,15 +51,10 @@ failures=0
 
 check() {
 	local description=$1 kernel=$2 machine=$3 libc=$4 expected=$5
-	local bin
+	local bin detector got
 	bin=$(stub_host "$kernel" "$machine" "$libc")
-	for detector in include_host_triplet bootstrap_host_triplet; do
-		local got
-		if [[ $detector == include_host_triplet ]]; then
-			got=$(detect_with_include "$bin") || got='<error>'
-		else
-			got=$(detect_with_bootstrap "$bin") || got='<error>'
-		fi
+	for detector in detect_with_include detect_with_bootstrap; do
+		got=$($detector "$bin") || got='<error>'
 		if [[ $got != "$expected" ]]; then
 			echo "$description ($detector): expected '$expected', got '$got'" >&2
 			failures=$((failures + 1))
@@ -79,6 +70,10 @@ check "macOS arm64" Darwin arm64 "" arm64-apple-darwin
 check "macOS x86_64" Darwin x86_64 "" x86_64-apple-darwin
 check "FreeBSD amd64" FreeBSD amd64 "" x86_64-unknown-freebsd
 check "FreeBSD arm64" FreeBSD arm64 "" aarch64-unknown-freebsd
+check "Windows MSYS" MSYS_NT-10.0 x86_64 "" x86_64-w64-mingw32
+check "Windows MINGW64" MINGW64_NT-10.0 x86_64 "" x86_64-w64-mingw32
+check "Windows Cygwin" CYGWIN_NT-10.0 x86_64 "" x86_64-w64-mingw32
+check "Windows MINGW32 is unsupported" MINGW32_NT-10.0 i686 "" '<error>'
 
 [[ $failures -eq 0 ]] || exit 1
 echo "host triplet detection OK"

--- a/tests/test-host-triplet.sh
+++ b/tests/test-host-triplet.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# The bootstrap script and the installed vdpm frontend each carry their own
+# copy of this detection, and both have to agree with what release.yml
+# actually publishes: linux-gnu vs. linux-musl only differ by libc, glibc
+# ceiling has no effect on the triplet, and FreeBSD's `uname -m` reports
+# "arm64" the same way Darwin does, so it has to be told apart by `uname -s`.
+
+set -euo pipefail
+
+directory=$(cd "$(dirname "$0")/.." && pwd -P)
+fixtures=$(mktemp -d)
+trap 'rm -rf "$fixtures"' EXIT
+
+# A fake uname/ldd pair placed ahead of the real ones on PATH, so the
+# detection functions run for real but see whichever host is under test.
+stub_host() {
+	local kernel=$1 machine=$2 libc=${3:-}
+	local bin="$fixtures/bin"
+	rm -rf "$bin"
+	mkdir -p "$bin"
+	cat > "$bin/uname" <<EOF
+#!/bin/sh
+case \$1 in
+	-s) echo '$kernel' ;;
+	-m) echo '$machine' ;;
+esac
+EOF
+	chmod +x "$bin/uname"
+	if [[ $libc == musl ]]; then
+		printf '#!/bin/sh\necho "musl libc (%s)"\n' "$machine" > "$bin/ldd"
+	else
+		printf '#!/bin/sh\necho "ldd (GNU libc) 2.39"\n' > "$bin/ldd"
+	fi
+	chmod +x "$bin/ldd"
+	printf '%s' "$bin"
+}
+
+detect_with_include() {
+	(
+		PATH="$1:$PATH"
+		source "$directory/include/host-triplet.sh"
+		vdpm_host_triplet
+	)
+}
+
+detect_with_bootstrap() {
+	(
+		PATH="$1:$PATH"
+		source <(sed -n '/^detect_host_triplet() {/,/^}/p' "$directory/bootstrap-vitasdk.sh")
+		detect_host_triplet
+	)
+}
+
+failures=0
+
+check() {
+	local description=$1 kernel=$2 machine=$3 libc=$4 expected=$5
+	local bin
+	bin=$(stub_host "$kernel" "$machine" "$libc")
+	for detector in include_host_triplet bootstrap_host_triplet; do
+		local got
+		if [[ $detector == include_host_triplet ]]; then
+			got=$(detect_with_include "$bin") || got='<error>'
+		else
+			got=$(detect_with_bootstrap "$bin") || got='<error>'
+		fi
+		if [[ $got != "$expected" ]]; then
+			echo "$description ($detector): expected '$expected', got '$got'" >&2
+			failures=$((failures + 1))
+		fi
+	done
+}
+
+check "Linux glibc x86_64" Linux x86_64 glibc x86_64-linux-gnu
+check "Linux glibc aarch64" Linux aarch64 glibc aarch64-linux-gnu
+check "Linux musl x86_64" Linux x86_64 musl x86_64-linux-musl
+check "Linux musl aarch64" Linux aarch64 musl aarch64-linux-musl
+check "macOS arm64" Darwin arm64 "" arm64-apple-darwin
+check "macOS x86_64" Darwin x86_64 "" x86_64-apple-darwin
+check "FreeBSD amd64" FreeBSD amd64 "" x86_64-unknown-freebsd
+check "FreeBSD arm64" FreeBSD arm64 "" aarch64-unknown-freebsd
+
+[[ $failures -eq 0 ]] || exit 1
+echo "host triplet detection OK"


### PR DESCRIPTION
## What does this change?

Teaches both copies of the host detection (`include/host-triplet.sh` and `bootstrap-vitasdk.sh`) the identities that #122 publishes bundles for: `*-linux-musl`, `*-unknown-freebsd`, and Cygwin as a Windows shell.

While doing so it fixes the detection itself:

- **musl detection survives `pipefail`.** Real musl `ldd` prints its banner and exits 1, so the old `ldd | grep` pipeline reported glibc on every actual musl host under the callers' `set -o pipefail`. Detection now captures the banner instead of piping it, and falls back to the musl loader on disk when no `ldd` exists at all.
- **The two copies agree about Windows.** They previously matched different environment sets; both now accept MSYS, MINGW64 and Cygwin, and reject MINGW32 (its `uname -m` is i686, which nothing publishes).
- **The contract test is faithful.** Its musl stub now behaves like real musl ldd (stderr, exit 1) — the exact shape that exposed the pipefail bug — it covers the Windows rows where the copies actually diverged, it runs in CI, and `test-channel-manifest.sh` sources the canonical detection instead of keeping a third private copy.
- **Bootstrap tells the truth when there is no seed.** A detected host whose seed release publishes no asset used to die blaming `VITASDK_BOOTSTRAP_SHA256`, a variable the user never set; it now names the host and release that have no published seed, and checks for curl/wget before the first download.

## Do not merge yet

This PR is deliberately gated. The new identities only lead somewhere once the whole chain serves them:

1. a vdpm release publishing seed assets for the new hosts (#122 merged, release cut);
2. channel manifests listing the new architectures (autobuilds side);
3. core packages built for them.

Merging earlier is a regression: musl machines currently bootstrap and refresh successfully under the glibc identity (glibc seed via compat), and flipping detection first would strand them at a channel that does not publish their host.

## Testing

`tests/test-host-triplet.sh` (12 rows × 2 detectors, faithful stubs) green locally; `shellcheck` and `actionlint` clean.

---
AI tools were used in preparing this PR (Claude Fable 5, Anthropic).
