### PR TITLE
Seed the installers from a release they accept

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
       - bootstrap-vitasdk.sh
       - tests/test-bootstrap-powershell.sh
       - tests/test-bootstrap-root-install.sh
+      - tests/test-bootstrap-seed.sh
       - tests/test-bootstrap-windows.ps1
       - tests/test-release-bundle.sh
       - .github/workflows/release.yml
@@ -77,6 +78,10 @@ jobs:
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash
         run: ./tests/test-bootstrap-root-install.sh
+      - name: Check the seed release carries what the installers require
+        if: matrix.host == 'x86_64-linux-gnu'
+        shell: bash
+        run: ./tests/test-bootstrap-seed.sh
       - uses: actions/cache@v6
         with:
           path: downloads

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,28 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  # The Windows installer has been run for real against the published channels
+  # for a while; the shell one never was. Every smoke test hands it a local
+  # archive, which is the one path that skips the seed and the channel index,
+  # so a seed the installer could not accept shipped and broke every install.
+  smoke-bootstrap:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install from the published channels, as a new user would
+        shell: bash
+        run: |
+          docker run --rm -v "$PWD":/src:ro ubuntu:24.04 bash -euc '
+            apt-get update -qq >/dev/null
+            apt-get install -y -qq curl ca-certificates bzip2 tar >/dev/null
+            /src/bootstrap-vitasdk.sh
+            /usr/local/vitasdk/bin/vdpm --help >/dev/null
+            /usr/local/vitasdk/libexec/vdpm/pacman --version >/dev/null
+            /usr/local/vitasdk/bin/arm-vita-eabi-gcc --version
+            printf "int main(){return 0;}\n" > /tmp/probe.c
+            /usr/local/vitasdk/bin/arm-vita-eabi-gcc -c /tmp/probe.c -o /tmp/probe.o
+          '
+
   collect:
     needs: [prepare, build-linux-container, build-macos, build-freebsd, smoke-freebsd, build-windows]
     runs-on: ubuntu-24.04

--- a/bootstrap-vitasdk.ps1
+++ b/bootstrap-vitasdk.ps1
@@ -22,8 +22,8 @@ if (Test-Path $InstallDirectory) {
 # script the root instead of them; that is a deliberate choice. The key digest
 # below is checked anyway, because it catches a seed that brings a different
 # channel key.
-$SeedRelease = 'v0.1.1'
-$SeedVersion = '0.1.1'
+$SeedRelease = 'v0.1.2'
+$SeedVersion = '0.1.2'
 $ChannelKeySha256 = 'c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307'
 $installFromPackages = $false
 

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -28,8 +28,8 @@ EOF
 #
 # What the network is never allowed to decide is which verifier to trust: the
 # manifest that says what to install is checked with the key already on disk.
-SEED_RELEASE=v0.1.1
-SEED_VERSION=0.1.1
+SEED_RELEASE=v0.1.2
+SEED_VERSION=0.1.2
 CHANNEL_KEY_SHA256=c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307
 
 install_from_packages=0

--- a/tests/test-bootstrap-seed.sh
+++ b/tests/test-bootstrap-seed.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# The seed release has to contain what the installer demands of it.
+#
+# Both installers download one pinned release as their seed and then check it
+# carries a fixed set of paths. Nothing tied the pin to that set, so when
+# pacman moved to libexec/vdpm the requirement moved with it and the pin did
+# not: every install on Linux and macOS died on "bootstrap archive is missing
+# libexec/vdpm/pacman", on every channel, while CI stayed green -- the smoke
+# tests all hand the installer a local archive, which skips the seed entirely.
+#
+# This reads the pin and the requirements out of the installers themselves,
+# so it keeps holding when either side changes.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-seed.XXXXXXXX")
+trap 'rm -rf -- "$temporary_directory"' EXIT
+
+shell_installer="$repository_root/bootstrap-vitasdk.sh"
+powershell_installer="$repository_root/bootstrap-vitasdk.ps1"
+
+seed_release=$(sed -n 's/^SEED_RELEASE=\(.*\)$/\1/p' "$shell_installer")
+seed_version=$(sed -n 's/^SEED_VERSION=\(.*\)$/\1/p' "$shell_installer")
+[[ -n $seed_release && -n $seed_version ]] || {
+	printf 'could not read the seed pin from %s\n' "$shell_installer" >&2
+	exit 1
+}
+
+powershell_release=$(sed -n "s/^\$SeedRelease = '\(.*\)'.*$/\1/p" "$powershell_installer")
+powershell_version=$(sed -n "s/^\$SeedVersion = '\(.*\)'.*$/\1/p" "$powershell_installer")
+[[ $powershell_release == "$seed_release" && $powershell_version == "$seed_version" ]] || {
+	printf 'the two installers seed from different releases: %s/%s and %s/%s\n' \
+		"$seed_release" "$seed_version" "$powershell_release" "$powershell_version" >&2
+	exit 1
+}
+
+# The requirements live in a case branch per host kind in the shell installer
+# and in an if branch in the PowerShell one; take each list as written.
+posix_requirements=$(
+	awk '
+		/seed_required=\(/ { collecting = 1; block = "" }
+		collecting { block = block " " $0 }
+		collecting && /\)/ { collecting = 0; if (block !~ /\.exe/) print block }
+	' "$shell_installer" |
+		sed 's/.*seed_required=(//; s/)[[:space:]]*$//; s/\\//g' |
+		tr -s ' \t' '\n' | grep -v '^$'
+)
+windows_requirements=$(
+	# shellcheck disable=SC2016 # the dollar sign is PowerShell's, not this shell's
+	sed -n '/\$installFromPackages) {/,/^    } else {/p' "$powershell_installer" |
+		sed -n 's/^ *"\(.*\)",\{0,1\}$/\1/p'
+)
+[[ -n $posix_requirements && -n $windows_requirements ]] || {
+	printf 'could not read the seed requirements out of the installers\n' >&2
+	exit 1
+}
+
+check_bundle() {
+	local host=$1 requirements=$2 archive listing missing=0
+	archive="$temporary_directory/vdpm-$seed_version-$host.tar.bz2"
+	curl -fsSL --retry 3 -o "$archive" \
+		"https://github.com/vitasdk/vdpm/releases/download/$seed_release/vdpm-$seed_version-$host.tar.bz2"
+	listing="$temporary_directory/$host.list"
+	tar -tjf "$archive" > "$listing"
+	while IFS= read -r relative_path; do
+		[[ -n $relative_path ]] || continue
+		grep -qx "vdpm-$seed_version-$host/$relative_path" "$listing" || {
+			printf 'seed %s for %s is missing %s\n' "$seed_release" "$host" "$relative_path" >&2
+			missing=1
+		}
+	done <<< "$requirements"
+	(( missing == 0 )) || exit 1
+	printf 'seed %s satisfies %s\n' "$seed_release" "$host"
+}
+
+check_bundle x86_64-linux-gnu "$posix_requirements"
+check_bundle x86_64-w64-mingw32 "$windows_requirements"
+
+printf 'bootstrap seed contract tests passed\n'


### PR DESCRIPTION
Installing VitaSDK on Linux or macOS has been impossible since v0.1.2 shipped. On any channel:

```
$ curl -fsSL .../bootstrap-vitasdk.sh | bash
VitaSDK bootstrap archive is missing libexec/vdpm/pacman
```

Both installers download one pinned release as their seed and then check it carries a fixed set of paths. When pacman moved to `libexec/vdpm`, the requirement moved with it (`seed_required`, line 274) and the pin did not (`SEED_RELEASE=v0.1.1`, line 31) — and v0.1.1 is the release right before the move, so its bundle has `bin/pacman`. The seed can never satisfy its own check.

Windows was not affected: its paths already matched in v0.1.1. Both seeds move to v0.1.2 anyway, so there is one thing to bump next time instead of two, and I verified the v0.1.2 Windows bundle carries every path that installer requires before touching it.

**Why CI stayed green through all of this:** every bootstrap smoke test we have — here, in autobuilds, in buildscripts — hands the installer a local archive through `VITASDK_BOOTSTRAP_ARCHIVE`. That path installs the given archive directly and never fetches a seed or resolves a channel. We were testing "install this exact tarball", which is what CI does, and never "a new user runs the installer", which is what people do. The bug lived in the gap.

`tests/test-bootstrap-seed.sh` closes it: it reads the pin and the requirements out of the installers themselves, downloads the seed for both host kinds, and asserts every required path is really in there. Reverting the pin to v0.1.1 makes it fail with the exact message users were getting, which is how I know it guards the right thing.

Verified end to end in a clean `ubuntu:24.04` container: with the bumped seed, `curl … | bash` installs, and `vdpm --help`, `libexec/vdpm/pacman --version` and `arm-vita-eabi-gcc --version` (15.2.0) all answer.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).