### PR TITLE
Fix the two channel scripts nothing ever ran

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
       - tests/pacman/**
       - bootstrap-vitasdk.sh
       - tests/test-bootstrap-powershell.sh
+      - tests/test-channels-powershell.sh
       - tests/test-bootstrap-root-install.sh
       - tests/test-bootstrap-seed.sh
       - tests/test-bootstrap-windows.ps1
@@ -79,6 +80,10 @@ jobs:
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash
         run: ./tests/test-bootstrap-powershell.sh
+      - name: Exercise the Windows channel listing under PowerShell
+        if: matrix.host == 'x86_64-linux-gnu'
+        shell: bash
+        run: ./tests/test-channels-powershell.sh
       - name: Install into a top-level directory
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
       - bootstrap-vitasdk.sh
       - tests/test-bootstrap-powershell.sh
       - tests/test-channels-powershell.sh
+      - tests/test-channel-names.sh
       - tests/test-bootstrap-root-install.sh
       - tests/test-bootstrap-seed.sh
       - tests/test-bootstrap-windows.ps1
@@ -84,6 +85,10 @@ jobs:
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash
         run: ./tests/test-channels-powershell.sh
+      - name: Check which series names a refresh accepts
+        if: matrix.host == 'x86_64-linux-gnu'
+        shell: bash
+        run: ./tests/test-channel-names.sh
       - name: Install into a top-level directory
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash

--- a/include/list-channels.ps1
+++ b/include/list-channels.ps1
@@ -17,7 +17,9 @@ if (-not $sdkRoot) {
 
 $channelTool = $env:VDPM_CHANNEL_TOOL
 if (-not $channelTool) {
-    $channelTool = Join-Path $sdkRoot "bin/vdpm-channel.exe"
+    # Where the Windows bootstrap installs it, which is not bin/:
+    # refresh-repositories.ps1 has always looked here.
+    $channelTool = Join-Path $sdkRoot "share/vdpm/msys/usr/bin/vdpm-channel.exe"
 }
 if (-not (Test-Path -LiteralPath $channelTool -PathType Leaf)) {
     throw "missing ${channelTool}"

--- a/include/refresh-repositories.ps1
+++ b/include/refresh-repositories.ps1
@@ -2,11 +2,19 @@ param(
     # Not a fixed list: a release series is a channel, so 2026.09 has to be
     # sayable. Still checked, because the name goes into a URL and a path.
     [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')]
-    [string]$Channel = "stable"
+    [string]$Channel = ""
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# No default. Refresh is what moves somebody between series, and the name
+# this used to assume -- stable -- is not a series: it 404s. vdpm refuses
+# without one, and so does this, for whoever runs it by hand. A parameter
+# default skips ValidatePattern, which is why the check is here.
+if (-not $Channel) {
+    throw 'refresh requires a series; run `vdpm channels` to see them'
+}
 
 function Require-RegularFile([string]$Path, [string]$Description) {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {

--- a/include/refresh-repositories.sh
+++ b/include/refresh-repositories.sh
@@ -2,9 +2,14 @@
 
 set -euo pipefail
 
-# No argument means the default channel; an empty one is a mistake, and
-# quietly turning it into stable would move somebody off their release.
-channel=${1-stable}
+# No default. Refresh is what moves somebody between series, and the name
+# this used to assume -- stable -- is not a series: it 404s. vdpm refuses
+# without one, and so does this, for whoever runs it by hand.
+[[ $# -ge 1 ]] || {
+	printf 'refresh requires a series; run `vdpm channels` to see them\n' >&2
+	exit 1
+}
+channel=$1
 # A channel is a name, not a fixed list: a release series is a channel that
 # lives as long as the release does, so 2026.09 has to be sayable. It is
 # still checked, because the name goes into a URL and a file path.

--- a/tests/test-channel-names.sh
+++ b/tests/test-channel-names.sh
@@ -14,9 +14,12 @@ refresher="${directory}/include/refresh-repositories.sh"
 
 refused()
 {
-    # Everything past the name check fails for unrelated reasons here, so
+    # By its shebang, the way vdpm spawns it. Under `sh` this says
+    # "Illegal option -o pipefail" wherever /bin/sh is dash, and then
+    # nothing is ever refused and every check below passes for nothing.
+    # Everything past the name check fails here for unrelated reasons, so
     # what is asserted is only whether the name itself was refused.
-    VITASDK= sh "${refresher}" "$1" 2>&1 | grep -q 'invalid channel name'
+    VITASDK= "${refresher}" "$1" 2>&1 | grep -q 'invalid channel name'
 }
 
 failures=0
@@ -36,6 +39,17 @@ for name in '../nightly' 'a/b' '' '-x' '.hidden' 'a..b' 'x;y' 'a b' 'a$b'; do
         failures=$((failures + 1))
     fi
 done
+
+# No series at all is not a name at all. Refresh is what moves somebody
+# between series, and the name this used to default to -- stable -- is not
+# one: it 404s. The way out is the same one vdpm names.
+if VITASDK= "${refresher}" >/dev/null 2>&1; then
+    echo "ran a refresh without being told which series" >&2
+    failures=$((failures + 1))
+elif ! VITASDK= "${refresher}" 2>&1 | grep -q 'run `vdpm channels`'; then
+    echo "refused a missing series without saying how to find one" >&2
+    failures=$((failures + 1))
+fi
 
 [ "${failures}" -eq 0 ] || exit 1
 echo "channel names OK"

--- a/tests/test-channels-powershell.sh
+++ b/tests/test-channels-powershell.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# `vdpm channels` on Windows, run where it can be run cheaply.
+#
+# The Windows half is PowerShell, which is not Windows-only, and neither was
+# the defect: list-channels.ps1 looked for the channel helper in bin/, and the
+# Windows bootstrap installs it under share/vdpm/msys/usr/bin/ -- as
+# refresh-repositories.ps1, its sibling, already knew. So the command died
+# with "missing" on every Windows installation, and it is the command vdpm's
+# own error names when you ask for a release without saying which one.
+#
+# Nothing executed this script before: the tests checked that the file was
+# installed, never that running it did anything.
+#
+# What this does not cover: the real helper, the real signatures, a real
+# Windows path. tests/test-channel-refresh-windows.ps1 covers a Windows
+# runner.
+#
+# On a machine without PowerShell:
+#
+#   docker run --rm --platform linux/amd64 -v "$PWD:/vdpm" -w /vdpm \
+#       mcr.microsoft.com/powershell:7.4-debian-12 ./tests/test-channels-powershell.sh
+
+set -euo pipefail
+
+repository=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+work=$(mktemp -d)
+server_pid=
+cleanup() {
+	[[ -z $server_pid ]] || kill "$server_pid" 2>/dev/null || true
+	rm -rf "$work"
+}
+trap cleanup EXIT
+
+failures=0
+check() {
+	if [[ $2 == "$3" ]]; then
+		printf 'ok: %s\n' "$1"
+	else
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$1" "$3" "$2"
+		failures=$((failures + 1))
+	fi
+}
+
+contains() {
+	if grep -qF -- "$2" <<<"$1"; then
+		printf 'ok: %s\n' "$3"
+	else
+		printf 'FAIL: %s\n  looked for: %s\n  in:\n%s\n' "$3" "$2" "$1"
+		failures=$((failures + 1))
+	fi
+}
+
+# The layout the Windows bootstrap produces, which is the whole point: the
+# helper lives under the MSYS tree, not in bin/.
+sdk=$work/sdk
+helper_directory=$sdk/share/vdpm/msys/usr/bin
+mkdir -p "$helper_directory" "$sdk/var/lib/vdpm" "$sdk/share/vdpm"
+cp "$repository/include/list-channels.ps1" "$sdk/share/vdpm/"
+: >"$sdk/share/vdpm/channel-public-key.pem"
+printf '{"channel":"2026.08","schema_version":1,"sequence":7}\n' \
+	>"$sdk/var/lib/vdpm/channel.json"
+
+cat >"$helper_directory/vdpm-channel.exe" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case ${1:-} in
+verify)
+	# $2 index, $3 signature, $4 public key: all three must reach it.
+	[[ -f $2 && -f $3 && -f $4 ]] || exit 1
+	printf 'verify %s\n' "$2" >>"$VDPM_CHANNEL_CALLS"
+	;;
+describe)
+	printf 'describe %s\n' "$2" >>"$VDPM_CHANNEL_CALLS"
+	printf 'channel\t2026.08\n'
+	;;
+series)
+	printf 'series %s\n' "$2" >>"$VDPM_CHANNEL_CALLS"
+	printf '2026.08\tsupported\tthe one this SDK follows\n'
+	printf 'nightly\trolling\tbuilt from every commit\n'
+	;;
+*) printf 'vdpm-channel: unexpected command: %s\n' "$*" >&2; exit 2 ;;
+esac
+STUB
+chmod +x "$helper_directory/vdpm-channel.exe"
+
+# A served index, because the script downloads before it does anything else:
+# without one the run dies at the network and proves nothing about the rest.
+served=$work/www
+mkdir -p "$served"
+printf '{"schema_version":1,"series":[]}\n' >"$served/index.json"
+printf 'not a real signature\n' >"$served/index.json.sig"
+
+python3 - "$served" "$work/port" <<'PYEOF' &
+import http.server, functools, sys
+directory, port_file = sys.argv[1], sys.argv[2]
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+handler = functools.partial(Quiet, directory=directory)
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+with open(port_file, "w") as handle:
+    handle.write(str(server.server_address[1]))
+server.serve_forever()
+PYEOF
+server_pid=$!
+
+for _ in $(seq 1 50); do
+	[[ -s $work/port ]] && break
+	sleep 0.1
+done
+[[ -s $work/port ]] || {
+	printf 'the index server never came up\n' >&2
+	exit 1
+}
+port=$(cat "$work/port")
+
+calls=$work/calls
+: >"$calls"
+if output=$(
+	VITASDK=$sdk \
+	VITASDK_CHANNEL_BASE_URL="http://127.0.0.1:$port" \
+	VDPM_CHANNEL_CALLS=$calls \
+		pwsh -NoProfile -File "$sdk/share/vdpm/list-channels.ps1" 2>&1
+); then
+	printf 'ok: the listing runs against the layout the bootstrap installs\n'
+else
+	printf 'FAIL: the listing failed\n%s\n' "$output"
+	failures=$((failures + 1))
+fi
+
+contains "$output" "RELEASE" "the table is printed"
+contains "$output" "*2026.08" "the series this installation follows is marked"
+contains "$output" "nightly" "the other series are listed"
+contains "$output" "* is the release this installation follows." "the marker is explained"
+
+# The index decides where people are told they may move to, so it is verified
+# before it is read, and kept for `vdpm status` to read offline.
+contains "$(cat "$calls")" "verify" "the index is verified before it is used"
+check "the index is kept for vdpm status" \
+	"$([[ -f $sdk/var/lib/vdpm/index.json ]] && echo yes || echo no)" "yes"
+
+if [[ $failures -gt 0 ]]; then
+	printf '\n%s check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+printf '\nvdpm channels on PowerShell: all checks passed\n'


### PR DESCRIPTION
`vdpm channels` has never worked on Windows.

```
PS> vdpm channels
Exception: ...\share\vdpm\list-channels.ps1:23
     23 |     throw "missing ${channelTool}"
        |     missing C:\vitasdk\bin\vdpm-channel.exe
```

The Windows bootstrap installs the helper under `share/vdpm/msys/usr/bin/` — `bootstrap-vitasdk.ps1:143`, `bootstrap-vitasdk.sh:290` and `tests/test-release-bundle.sh:54` all agree on that — and `include/list-channels.ps1` looked in `bin/`. It dies before it reaches the network, so no installation has ever seen the listing.

It is also the command vdpm's own error points you at when you ask for a release without naming one, which made that message a dead end on Windows.

`include/refresh-repositories.ps1:79` has always looked in the right place. Nothing made the two agree because **nothing ever ran this file**: `tests/test-bootstrap-powershell.sh` and `tests/test-bootstrap-windows.ps1` check that it is installed, and stop there.

So it runs now, the way `tests/test-bootstrap-powershell.sh` already runs the installer — under `pwsh` on the Linux runner, against the layout the bootstrap produces, with a stub helper and an index served from a loopback port. It checks what the command is for: the table prints, the series this installation follows is marked with `*`, the index is verified before it is read, and it is kept in `var/lib/vdpm/` for `vdpm status` to read offline. Against the parent commit it fails seven checks, naming the path it could not find:

```
$ tests/test-channels-powershell.sh
...
        |     missing /tmp/.../sdk/bin/vdpm-channel.exe
FAIL: the index is verified before it is used
FAIL: the index is kept for vdpm status

7 check(s) failed
```

`VDPM_CHANNEL_TOOL` still overrides the location, so the test exercises the default path rather than stepping around it. The POSIX half was already right (`$VITASDK/bin/vdpm-channel`, which `tests/test-channel-status.sh` exercises) and is untouched.


---

## Second commit: the refresh helper's dead `stable` default

`vdpm refresh` has no default — refresh is what moves somebody between series, and the name it used to assume, `stable`, is not a series, so it 404s. `src/vdpm.c:934` says exactly that and stops:

```c
/* No default. Refresh is what moves somebody between series, and
 * the name it used to assume -- stable -- is not a series. */
```

Both helper scripts still carried the default (`include/refresh-repositories.sh:7`, `include/refresh-repositories.ps1:5`), so running either by hand walked straight into the 404 the frontend exists to prevent. They refuse with the same sentence now, and point at the same way out.

`tests/test-channel-names.sh` covers it, and had to be repaired first. It ran the helper under `sh`:

```
$ VITASDK= dash include/refresh-repositories.sh '../evil'
include/refresh-repositories.sh: 3: set: Illegal option -o pipefail
```

Wherever `/bin/sh` is dash — every Ubuntu runner — the helper dies before it reaches the name check, so nothing is ever refused: the loop of valid names passes vacuously, the loop of unsafe names fails, and the assertion means nothing either way. It runs the helper by its shebang now, the way `vdpm` spawns it.

**And that test was registered with `ctest`, which this repository never runs** — not in a workflow, not in a script. It runs as a step now, beside the others. `test-vdpm.sh`, `test-channel-manifest.sh` and `test-bootstrap.sh` are in the same position and pass today; wiring them up belongs in its own change.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
