### PR TITLE
Seed a release from itself, and check the seed agrees about hosts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,6 +418,29 @@ jobs:
           pattern: vdpm-*
           path: release
           merge-multiple: true
+      # A release seeds from itself. The pin in the tree is what somebody
+      # running the installer out of a git checkout gets, so it names the
+      # newest published release and is a real answer; what goes out with a
+      # release names that release, because the seeds are in it. Nothing is
+      # left to remember: the pin used to be a constant somebody had to bump,
+      # and it sat three releases behind until a musl host tripped over it.
+      #
+      # Safe because the release below is a transaction: created as a draft,
+      # every asset uploaded, downloaded back and compared, and only then
+      # published. Nobody can fetch the installer before its seeds exist.
+      - name: Seed this release from itself
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          tag=$GITHUB_REF_NAME
+          sed -i "s/^SEED_RELEASE=.*/SEED_RELEASE=$tag/; s/^SEED_VERSION=.*/SEED_VERSION=$VERSION/" \
+            bootstrap-vitasdk.sh
+          sed -i "s/^\$SeedRelease = .*/\$SeedRelease = '$tag'/; s/^\$SeedVersion = .*/\$SeedVersion = '$VERSION'/" \
+            bootstrap-vitasdk.ps1
+          grep -H '^SEED_RELEASE=\|^SEED_VERSION=' bootstrap-vitasdk.sh
+          grep -H 'SeedRelease\|SeedVersion' bootstrap-vitasdk.ps1
+
       - name: Verify complete release set
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ on:
       - tests/test-channel-names.sh
       - tests/test-bootstrap-root-install.sh
       - tests/test-bootstrap-seed.sh
+      - tests/test-stamp-seed.sh
+      - scripts/stamp-seed.sh
       - tests/test-bootstrap-windows.ps1
       - tests/test-host-triplet.sh
       - tests/test-release-bundle.sh
@@ -97,6 +99,10 @@ jobs:
         if: matrix.host == 'x86_64-linux-gnu'
         shell: bash
         run: ./tests/test-bootstrap-seed.sh
+      - name: Check a release can stamp its own seed pin
+        if: matrix.host == 'x86_64-linux-gnu'
+        shell: bash
+        run: ./tests/test-stamp-seed.sh
       - uses: actions/cache@v6
         with:
           path: downloads
@@ -428,18 +434,14 @@ jobs:
       # Safe because the release below is a transaction: created as a draft,
       # every asset uploaded, downloaded back and compared, and only then
       # published. Nobody can fetch the installer before its seeds exist.
+      # Only when a tag is being cut. Every other run of this job exists to
+      # prove the release set still builds, and there is no release for those
+      # to seed from -- a pull request's ref name is <number>/merge, which is
+      # not a tag and would not be a pin.
       - name: Seed this release from itself
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          tag=$GITHUB_REF_NAME
-          sed -i "s/^SEED_RELEASE=.*/SEED_RELEASE=$tag/; s/^SEED_VERSION=.*/SEED_VERSION=$VERSION/" \
-            bootstrap-vitasdk.sh
-          sed -i "s/^\$SeedRelease = .*/\$SeedRelease = '$tag'/; s/^\$SeedVersion = .*/\$SeedVersion = '$VERSION'/" \
-            bootstrap-vitasdk.ps1
-          grep -H '^SEED_RELEASE=\|^SEED_VERSION=' bootstrap-vitasdk.sh
-          grep -H 'SeedRelease\|SeedVersion' bootstrap-vitasdk.ps1
+        run: scripts/stamp-seed.sh "$GITHUB_REF_NAME" '${{ needs.prepare.outputs.version }}'
 
       - name: Verify complete release set
         shell: bash

--- a/bootstrap-vitasdk.ps1
+++ b/bootstrap-vitasdk.ps1
@@ -22,8 +22,8 @@ if (Test-Path $InstallDirectory) {
 # script the root instead of them; that is a deliberate choice. The key digest
 # below is checked anyway, because it catches a seed that brings a different
 # channel key.
-$SeedRelease = 'v0.1.2'
-$SeedVersion = '0.1.2'
+$SeedRelease = 'v0.1.4'
+$SeedVersion = '0.1.4'
 $ChannelKeySha256 = 'c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307'
 $installFromPackages = $false
 

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -28,8 +28,8 @@ EOF
 #
 # What the network is never allowed to decide is which verifier to trust: the
 # manifest that says what to install is checked with the key already on disk.
-SEED_RELEASE=v0.1.2
-SEED_VERSION=0.1.2
+SEED_RELEASE=v0.1.4
+SEED_VERSION=0.1.4
 CHANNEL_KEY_SHA256=c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307
 
 install_from_packages=0

--- a/scripts/stamp-seed.sh
+++ b/scripts/stamp-seed.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Point the installers at the release being cut.
+#
+# The installer downloads a seed and the seed then resolves the host itself,
+# so the two have to be the same vintage. Leaving that to a constant somebody
+# remembers to bump is what left musl and FreeBSD hosts installing an SDK for
+# the wrong libc: the pin sat three releases behind and nothing said so.
+#
+# The value kept in the tree names the newest published release, because that
+# is what somebody running the installer out of a git checkout gets and it has
+# to be a real answer. This rewrites it, at release time, to the release whose
+# seeds are going out beside it.
+
+set -euo pipefail
+
+usage() {
+	printf 'usage: %s <tag> <version>\n' "$0" >&2
+	exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+tag=$1
+version=$2
+
+# A tag reaches this as a ref name, and a ref name is not always a tag: on a
+# pull request it is <number>/merge. Refusing here rather than substituting it
+# keeps a nonsense pin out of an installer.
+[[ $tag =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+	printf 'not a release tag: %s\n' "$tag" >&2
+	exit 1
+}
+[[ $version =~ ^[0-9][A-Za-z0-9._-]*$ ]] || {
+	printf 'not a version: %s\n' "$version" >&2
+	exit 1
+}
+
+directory=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+sed -i.bak \
+	-e "s|^SEED_RELEASE=.*|SEED_RELEASE=$tag|" \
+	-e "s|^SEED_VERSION=.*|SEED_VERSION=$version|" \
+	"$directory/bootstrap-vitasdk.sh"
+sed -i.bak \
+	-e "s|^\$SeedRelease = .*|\$SeedRelease = '$tag'|" \
+	-e "s|^\$SeedVersion = .*|\$SeedVersion = '$version'|" \
+	"$directory/bootstrap-vitasdk.ps1"
+rm -f "$directory/bootstrap-vitasdk.sh.bak" "$directory/bootstrap-vitasdk.ps1.bak"
+
+grep -H '^SEED_RELEASE=\|^SEED_VERSION=' "$directory/bootstrap-vitasdk.sh"
+grep -H 'SeedRelease\|SeedVersion' "$directory/bootstrap-vitasdk.ps1" | head -2

--- a/tests/test-bootstrap-seed.sh
+++ b/tests/test-bootstrap-seed.sh
@@ -78,4 +78,39 @@ check_bundle() {
 check_bundle x86_64-linux-gnu "$posix_requirements"
 check_bundle x86_64-w64-mingw32 "$windows_requirements"
 
+# The seed has to agree with the installer about what a host is, not only
+# carry the right files. It re-detects the host itself -- vdpm refresh runs
+# from the seed -- so a seed whose detection is older than the installer's
+# installs a package set for a host nobody asked for. That is how a musl host
+# came to bootstrap a glibc SDK that cannot execute: the installer detected
+# musl, downloaded the musl seed, and the seed said gnu.
+check_detection() {
+	local host=$1 archive extracted
+	archive="$temporary_directory/vdpm-$seed_version-$host.tar.bz2"
+	extracted="$temporary_directory/extracted-$host"
+	mkdir -p "$extracted"
+	tar -xjf "$archive" -C "$extracted"
+	local seed_detection="$extracted/vdpm-$seed_version-$host/bin/include/host-triplet.sh"
+	[[ -f $seed_detection ]] || {
+		printf 'seed %s for %s carries no host-triplet.sh\n' "$seed_release" "$host" >&2
+		exit 1
+	}
+	# Compared by what they do, not byte for byte: comments and formatting are
+	# allowed to differ, the set of triplets either can answer is not.
+	local ours theirs
+	ours=$(grep -oE "'%s-[a-z0-9_-]+" "$repository_root/include/host-triplet.sh" | sort -u)
+	theirs=$(grep -oE "'%s-[a-z0-9_-]+" "$seed_detection" | sort -u)
+	[[ $ours == "$theirs" ]] || {
+		printf 'seed %s detects different hosts from this tree.\n' "$seed_release" >&2
+		printf '  this tree: %s\n' "$(tr '\n' ' ' <<< "$ours")" >&2
+		printf '  the seed:  %s\n' "$(tr '\n' ' ' <<< "$theirs")" >&2
+		printf 'Bump the seed pin, or the installer will hand work to a seed that\n' >&2
+		printf 'resolves the host differently from the way it was resolved here.\n' >&2
+		exit 1
+	}
+	printf 'seed %s resolves hosts the way this tree does\n' "$seed_release"
+}
+
+check_detection x86_64-linux-gnu
+
 printf 'bootstrap seed contract tests passed\n'

--- a/tests/test-stamp-seed.sh
+++ b/tests/test-stamp-seed.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# The release stamps its own seed pin into both installers.
+#
+# The value in the tree names the newest published release, for somebody
+# running the installer out of a checkout. What goes out with a release has to
+# name that release instead, whose seeds are published beside it -- otherwise
+# the pin is a constant somebody remembers to bump, which is how musl and
+# FreeBSD hosts came to install an SDK for the wrong libc.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+work=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-stamp.XXXXXXXX")
+trap 'rm -rf -- "$work"' EXIT
+
+failures=0
+
+# A copy of the tree, so the real installers are never edited by a test.
+mkdir -p "$work/scripts"
+cp "$repository_root/bootstrap-vitasdk.sh" "$repository_root/bootstrap-vitasdk.ps1" "$work/"
+cp "$repository_root/scripts/stamp-seed.sh" "$work/scripts/"
+
+check() {
+	local description=$1 expected=$2 actual=$3
+	if [[ $actual == "$expected" ]]; then
+		printf 'PASS: %s\n' "$description"
+	else
+		printf 'FAIL: %s\n  expected %s\n  got      %s\n' \
+			"$description" "$expected" "$actual" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+"$work/scripts/stamp-seed.sh" v9.9.9 9.9.9 >/dev/null
+
+check "the shell installer names the release" "SEED_RELEASE=v9.9.9" \
+	"$(grep '^SEED_RELEASE=' "$work/bootstrap-vitasdk.sh")"
+check "the shell installer names the version" "SEED_VERSION=9.9.9" \
+	"$(grep '^SEED_VERSION=' "$work/bootstrap-vitasdk.sh")"
+check "the PowerShell installer names the release" "\$SeedRelease = 'v9.9.9'" \
+	"$(grep '^\$SeedRelease' "$work/bootstrap-vitasdk.ps1")"
+check "the PowerShell installer names the version" "\$SeedVersion = '9.9.9'" \
+	"$(grep '^\$SeedVersion' "$work/bootstrap-vitasdk.ps1")"
+
+# Still a program afterwards. A pin is rewritten in place and nothing else is.
+bash -n "$work/bootstrap-vitasdk.sh" || {
+	printf 'FAIL: the shell installer is no longer valid bash\n' >&2
+	failures=$((failures + 1))
+}
+
+# A ref name is not always a tag: on a pull request it is <number>/merge, and
+# the slash used to end the sed expression rather than the pin. Refusing is
+# what keeps a nonsense pin out of a published installer.
+if "$work/scripts/stamp-seed.sh" 126/merge 0.105.1 >/dev/null 2>&1; then
+	printf 'FAIL: a pull request ref name was accepted as a release tag\n' >&2
+	failures=$((failures + 1))
+else
+	printf 'PASS: a pull request ref name is refused\n'
+fi
+
+if (( failures )); then
+	printf '%d seed stamping check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+printf 'seed stamping tests passed\n'


### PR DESCRIPTION
The installer detects the host and downloads the seed for it — and then **the seed detects the host again**, because `vdpm refresh` runs from the seed. Nothing made the two agree, and they stopped agreeing: host detection learned about musl and FreeBSD in v0.1.4, the pin still named v0.1.2, and v0.1.2's copy knows neither.

So a musl host installs a **glibc** SDK. The bootstrap looks fine and the first thing anyone runs says:

```
$ arm-vita-eabi-gcc ...
cannot execute: required file not found
$ grep ^Architecture $VITASDK/etc/pacman.conf
Architecture = aarch64-linux-gnu vita
```

Traced with `bash -x` on Alpine: `host=aarch64-linux-musl` → downloads `vdpm-0.1.2-aarch64-linux-musl.tar.bz2` → the seed re-detects → `gnu` → installs a glibc core. The musl builds are published on every run and have been unreachable through the supported install path since; the same holds for FreeBSD.

### Three things, because any one alone lets it happen again

**The pin moves to v0.1.4.** Fixes it today with what is already published. Verified on Alpine against the *supported* channel, not nightly:

```
Architecture = aarch64-linux-musl vita
arm-vita-eabi-gcc: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV)

gcc OK / vita-elf-create OK / vita-make-fself OK / vita-mksfoex OK
eboot.bin 76650 bytes
```

**A release seeds from itself.** The pin in the tree is what somebody running the installer out of a git checkout gets, so it names the newest published release and stays a real answer; what goes out *with* a release names that release, whose seeds are in it. Safe because the release is already a transaction — created as a draft, every asset uploaded, downloaded back and compared, published only then — so the installer cannot be fetched before its seeds exist. And the constant nobody remembered to bump stops being a constant anybody has to remember.

**The seed contract test compares behaviour, not only files.** That test already exists because this exact shape of drift happened once before, when pacman moved to `libexec/vdpm` and the pin did not follow. It checks the seed carries the paths the installer demands — which a seed that resolves hosts differently still does. It now also checks both resolve the same set of triplets. Against v0.1.2 it fails, naming what is missing:

```
seed v0.1.2 detects different hosts from this tree.
  this tree: '%s-apple-darwin '%s-linux-gnu '%s-linux-musl '%s-unknown-freebsd '%s-w64-mingw32
  the seed:  '%s-apple-darwin '%s-linux-gnu '%s-w64-mingw32
```

### Note

Nothing reaches users until a release is cut: what people download is the release asset, not the file in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)