### PR TITLE
Pin the tree's seed at v0.1.5

### DIFF
--- a/bootstrap-vitasdk.ps1
+++ b/bootstrap-vitasdk.ps1
@@ -22,8 +22,8 @@ if (Test-Path $InstallDirectory) {
 # script the root instead of them; that is a deliberate choice. The key digest
 # below is checked anyway, because it catches a seed that brings a different
 # channel key.
-$SeedRelease = 'v0.1.4'
-$SeedVersion = '0.1.4'
+$SeedRelease = 'v0.1.5'
+$SeedVersion = '0.1.5'
 $ChannelKeySha256 = 'c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307'
 $installFromPackages = $false
 

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -28,8 +28,8 @@ EOF
 #
 # What the network is never allowed to decide is which verifier to trust: the
 # manifest that says what to install is checked with the key already on disk.
-SEED_RELEASE=v0.1.4
-SEED_VERSION=0.1.4
+SEED_RELEASE=v0.1.5
+SEED_VERSION=0.1.5
 CHANNEL_KEY_SHA256=c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307
 
 install_from_packages=0


### PR DESCRIPTION
v0.1.5 is published, so it is what a git checkout should seed from. The release bundles already seed from themselves — `bootstrap-vitasdk.sh` inside v0.1.5 says `SEED_RELEASE=v0.1.5` — this is the tree catching up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)