### PR TITLE
Read the world from the channel, instead of assuming there is one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ on:
       - scripts/stamp-seed.sh
       - tests/test-bootstrap-windows.ps1
       - tests/test-host-triplet.sh
+      - tests/test-refresh-worlds.sh
       - tests/test-release-bundle.sh
       - .github/workflows/release.yml
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
       - tests/test-bootstrap-windows.ps1
       - tests/test-host-triplet.sh
       - tests/test-refresh-worlds.sh
+      - tests/test-channel-worlds-listing.sh
       - tests/test-release-bundle.sh
       - .github/workflows/release.yml
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
       - tests/test-host-triplet.sh
       - tests/test-refresh-worlds.sh
       - tests/test-channel-worlds-listing.sh
+      - tests/test-series-autoselection.sh
       - tests/test-release-bundle.sh
       - .github/workflows/release.yml
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,4 +89,7 @@ if(BUILD_TESTING AND UNIX)
     add_test(NAME vdpm-refresh-worlds
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-refresh-worlds.sh")
     set_tests_properties(vdpm-refresh-worlds PROPERTIES SKIP_RETURN_CODE 77)
+    add_test(NAME vdpm-channel-worlds-listing
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-channel-worlds-listing.sh")
+    set_tests_properties(vdpm-channel-worlds-listing PROPERTIES SKIP_RETURN_CODE 77)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,4 +86,7 @@ if(BUILD_TESTING AND UNIX)
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-bootstrap.sh")
     add_test(NAME vdpm-host-triplet-contract
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-host-triplet.sh")
+    add_test(NAME vdpm-refresh-worlds
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-refresh-worlds.sh")
+    set_tests_properties(vdpm-refresh-worlds PROPERTIES SKIP_RETURN_CODE 77)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,4 +92,7 @@ if(BUILD_TESTING AND UNIX)
     add_test(NAME vdpm-channel-worlds-listing
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-channel-worlds-listing.sh")
     set_tests_properties(vdpm-channel-worlds-listing PROPERTIES SKIP_RETURN_CODE 77)
+    add_test(NAME vdpm-series-autoselection
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/test-series-autoselection.sh")
+    set_tests_properties(vdpm-series-autoselection PROPERTIES SKIP_RETURN_CODE 77)
 endif()

--- a/bootstrap-vitasdk.ps1
+++ b/bootstrap-vitasdk.ps1
@@ -25,6 +25,9 @@ if (Test-Path $InstallDirectory) {
 $SeedRelease = 'v0.1.5'
 $SeedVersion = '0.1.5'
 $ChannelKeySha256 = 'c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307'
+# The world somebody gets when they do not ask for one. A world decides the
+# ABI of everything the toolchain compiles, so it is never picked for them.
+$DefaultWorld = 'vita'
 $installFromPackages = $false
 
 if ($ArchivePath -and -not $Sha256 -and (Test-Path "${ArchivePath}.sha256")) {
@@ -195,12 +198,22 @@ try {
                 throw "the release index is not signed by the expected key"
             }
             $index = Get-Content $indexPath -Raw | ConvertFrom-Json
+            # Only within the default world. A second world's series is named
+            # after the same month -- 2026.11-softfp against 2026.11 -- and
+            # this sorts names as text, so the longer one wins and whoever
+            # asked for no world in particular gets the one that changes the
+            # ABI of everything they compile. Asking by name still works:
+            # this runs only when nobody named a series.
             $Channel = $index.channels.PSObject.Properties |
-                Where-Object { $_.Value.status -eq "supported" } |
+                Where-Object {
+                    $_.Value.status -eq "supported" -and
+                    ($(if ($_.Value.PSObject.Properties['world']) {
+                        $_.Value.world } else { $DefaultWorld })) -eq $DefaultWorld
+                } |
                 Sort-Object -Property Name -Descending |
                 Select-Object -First 1 -ExpandProperty Name
             if (-not $Channel) {
-                throw "the release index lists no supported series"
+                throw "the release index lists no supported series for $DefaultWorld"
             }
             Write-Host "Installing the supported series $Channel"
         }

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -31,6 +31,9 @@ EOF
 SEED_RELEASE=v0.1.5
 SEED_VERSION=0.1.5
 CHANNEL_KEY_SHA256=c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307
+# The world somebody gets when they do not ask for one. A world decides the
+# ABI of everything the toolchain compiles, so it is never picked for them.
+DEFAULT_WORLD=vita
 
 install_from_packages=0
 resolve_series=0
@@ -325,10 +328,26 @@ if (( resolve_series )) && [[ -z $channel || $channel == stable ]]; then
 	}
 	# Series are named YYYY.MM, so the newest one is the highest year and
 	# then the highest month.
-	channel=$(grep -o '"[^"]*":{"status":"supported"' "$index" | cut -d'"' -f2 |
+	#
+	# Only within the default world. A second world's series is named after
+	# the same month -- 2026.11-softfp against 2026.11 -- and sorting by
+	# YYYY.MM cannot tell them apart, so whoever asked for no world in
+	# particular could have been handed one that changes the ABI of
+	# everything they compile. Asking for it by name still works: this runs
+	# only when nobody named a series.
+	#
+	# The helper doing the reading is the seed's, which may predate worlds
+	# and print three fields instead of four. A seed that cannot say is
+	# treated as saying the default, which is what it meant: no series of a
+	# second world is ever marked supported before a seed that can tell
+	# them apart is the one being pinned here.
+	channel=$("$staging_directory/$channel_tool" series "$index" |
+		awk -F'\t' -v world="$DEFAULT_WORLD" \
+			'$2 == "supported" && ($4 == "" ? world : $4) == world { print $1 }' |
 		sort -t. -k1,1nr -k2,2nr | head -n1)
 	[[ -n $channel ]] || {
-		printf 'the release index lists no supported series\n' >&2
+		printf 'the release index lists no supported series for %s\n' \
+			"$DEFAULT_WORLD" >&2
 		exit 1
 	}
 	printf 'Installing the supported series %s\n' "$channel" >&2

--- a/include/list-channels.ps1
+++ b/include/list-channels.ps1
@@ -67,15 +67,35 @@ try {
     New-Item -ItemType Directory -Path $stateDirectory -Force | Out-Null
     Copy-Item -LiteralPath $index -Destination (Join-Path $stateDirectory "index.json") -Force
 
-    "{0,-14} {1,-14} {2}" -f "RELEASE", "STATUS", "SUMMARY"
+    $rows = @()
     foreach ($line in @(& $channelTool series $index)) {
-        $parts = $line -split "`t", 3
+        $parts = $line -split "`t", 4
         if ($parts.Length -lt 2) { continue }
+        $rows += ,@{
+            Name = $parts[0]
+            Status = $parts[1]
+            Summary = $(if ($parts.Length -ge 3) { $parts[2] } else { "" })
+            World = $(if ($parts.Length -ge 4) { $parts[3] } else { "" })
+        }
+    }
+    # The world column appears only once there is more than one, so the
+    # listing everybody already reads does not grow a column saying the only
+    # answer.
+    $manyWorlds = (@($rows | ForEach-Object { $_.World } | Sort-Object -Unique)).Count -gt 1
+    if ($manyWorlds) {
+        "{0,-14} {1,-14} {2,-14} {3}" -f "RELEASE", "STATUS", "WORLD", "SUMMARY"
+    } else {
+        "{0,-14} {1,-14} {2}" -f "RELEASE", "STATUS", "SUMMARY"
+    }
+    foreach ($row in $rows) {
         $marker = " "
-        if ($parts[0] -eq $current) { $marker = "*" }
-        $summary = ""
-        if ($parts.Length -ge 3) { $summary = $parts[2] }
-        "{0}{1,-13} {2,-14} {3}" -f $marker, $parts[0], $parts[1], $summary
+        if ($row.Name -eq $current) { $marker = "*" }
+        if ($manyWorlds) {
+            "{0}{1,-13} {2,-14} {3,-14} {4}" -f `
+                $marker, $row.Name, $row.Status, $row.World, $row.Summary
+        } else {
+            "{0}{1,-13} {2,-14} {3}" -f $marker, $row.Name, $row.Status, $row.Summary
+        }
     }
     if ($current) {
         ""

--- a/include/list-channels.sh
+++ b/include/list-channels.sh
@@ -59,11 +59,25 @@ fi
 mkdir -p "$VITASDK/var/lib/vdpm"
 cp "$index" "$VITASDK/var/lib/vdpm/index.json"
 
-printf '%-14s %-14s %s\n' 'RELEASE' 'STATUS' 'SUMMARY'
-while IFS=$'\t' read -r name status summary; do
+# The world column appears only once there is more than one, so the listing
+# everybody already reads does not grow a column saying the only answer.
+rows=$("$channel_tool" series "$index")
+worlds=$(cut -f4 <<< "$rows" | sort -u | wc -l)
+
+if (( worlds > 1 )); then
+	printf '%-14s %-14s %-14s %s\n' 'RELEASE' 'STATUS' 'WORLD' 'SUMMARY'
+else
+	printf '%-14s %-14s %s\n' 'RELEASE' 'STATUS' 'SUMMARY'
+fi
+while IFS=$'\t' read -r name status summary world; do
 	marker=' '
 	[[ $name == "$current" ]] && marker='*'
-	printf '%s%-13s %-14s %s\n' "$marker" "$name" "$status" "$summary"
-done < <("$channel_tool" series "$index")
+	if (( worlds > 1 )); then
+		printf '%s%-13s %-14s %-14s %s\n' \
+			"$marker" "$name" "$status" "$world" "$summary"
+	else
+		printf '%s%-13s %-14s %s\n' "$marker" "$name" "$status" "$summary"
+	fi
+done <<< "$rows"
 
 [[ -z $current ]] || printf '\n* is the release this installation follows.\n'

--- a/include/refresh-repositories.ps1
+++ b/include/refresh-repositories.ps1
@@ -137,15 +137,35 @@ try {
         throw "package repository database SHA-256 mismatch"
     }
 
+    # The world and the repository come from the manifest that was just
+    # verified, not from here. See the shell installer for why.
+    $world = Manifest-Field "world"
+    $repository = $vitaName -replace '\.db$', ''
+
+    $configurationPath = Join-Path (Join-Path $sdkRoot "etc") "pacman.conf"
+    if (Test-Path -LiteralPath $configurationPath) {
+        # A configuration with no world after the host predates worlds and is
+        # not a mismatch; only a different one is.
+        $match = Select-String -LiteralPath $configurationPath `
+            -Pattern '^Architecture = \S+ (\S+)\s*$' | Select-Object -First 1
+        if ($match) {
+            $installed = $match.Matches[0].Groups[1].Value
+            if ($installed -ne $world) {
+                throw ("this installation is $installed and channel $Channel is $world; " +
+                       "changing world needs a new VITASDK root, not a refresh")
+            }
+        }
+    }
+
     $configuration = Join-Path $temporaryRoot "pacman.conf"
     $lines = @(
         "[options]",
-        "Architecture = $hostTriplet vita",
+        "Architecture = $hostTriplet $world",
         "# vdpm verifies signed channel metadata and the selected database hash before use.",
         "SigLevel = Never",
         "[$hostTriplet]",
         "Server = $(Manifest-Field 'core.server')",
-        "[vita]",
+        "[$repository]",
         "Server = $(Manifest-Field 'packages.server')"
     )
     [IO.File]::WriteAllText($configuration, ($lines -join "`n") + "`n",
@@ -158,7 +178,7 @@ try {
         New-Item -ItemType Directory -Force -Path $_ | Out-Null
     }
     Install-File $coreDatabase (Join-Path $syncRoot "${hostTriplet}.db")
-    Install-File $vitaDatabase (Join-Path $syncRoot "vita.db")
+    Install-File $vitaDatabase (Join-Path $syncRoot $vitaName)
     # Staged, not selected: the transaction that moves the toolchain runs
     # after this, and until it succeeds the installation is still on the
     # series whose compiler it actually has.

--- a/include/refresh-repositories.sh
+++ b/include/refresh-repositories.sh
@@ -98,29 +98,48 @@ download_database() {
 	fi
 }
 
+# The world and the repository come from the manifest that was just verified,
+# not from here. This used to say vita in three places, which was right while
+# that was the only world and wrong for the first package of the second.
+world=$(value world)
+packages_database_name=$(value packages.database.name)
+repository=${packages_database_name%.db}
+
 core_database="$temporary_directory/$host.db"
-vita_database="$temporary_directory/vita.db"
+vita_database="$temporary_directory/$packages_database_name"
 download_database "$(value core.database.url)" \
 	"$(value core.database.name)" "$core_database"
 download_database "$(value packages.database.url)" \
-	"$(value packages.database.name)" "$vita_database"
+	"$packages_database_name" "$vita_database"
 verify_hash "$(value core.database.sha256)" "$core_database"
 verify_hash "$(value packages.database.sha256)" "$vita_database"
+
+# Changing the world under an installation would leave a sysroot of one ABI
+# with a package database of another, and pacman cannot tell them apart by
+# file name. A new world is a new root.
+installed_world=$(sed -n 's/^Architecture = [^ ]* //p' \
+	"$VITASDK/etc/pacman.conf" 2>/dev/null || true)
+[[ -z $installed_world || $installed_world == "$world" ]] || {
+	printf 'this installation is %s and channel %s is %s\n' \
+		"$installed_world" "$channel" "$world" >&2
+	printf 'changing world needs a new VITASDK root, not a refresh\n' >&2
+	exit 1
+}
 
 mkdir -p "$VITASDK/etc" "$VITASDK/var/lib/pacman/sync" "$VITASDK/var/lib/vdpm"
 configuration="$temporary_directory/pacman.conf"
 cat > "$configuration" <<EOF
 [options]
-Architecture = $host vita
+Architecture = $host $world
 # vdpm verifies signed channel metadata and the selected database hash before use.
 SigLevel = Never
 [$host]
 Server = $(value core.server)
-[vita]
+[$repository]
 Server = $(value packages.server)
 EOF
 cp "$core_database" "$VITASDK/var/lib/pacman/sync/$host.db"
-cp "$vita_database" "$VITASDK/var/lib/pacman/sync/vita.db"
+cp "$vita_database" "$VITASDK/var/lib/pacman/sync/$packages_database_name"
 mv "$configuration" "$VITASDK/etc/pacman.conf"
 
 # The selection is staged, not made. Moving between series is a package

--- a/src/vdpm-channel.c
+++ b/src/vdpm-channel.c
@@ -455,12 +455,18 @@ static int check_section(const struct node *section, const char **error)
 	return 1;
 }
 
+/* The world a version 1 manifest is for when it does not say. It is the only
+ * world that existed while version 1 was the current schema, so a manifest
+ * written then can only have meant this one. Version 2 has to say. */
+#define DEFAULT_WORLD "vita"
+
 struct manifest {
 	struct node *root;
 	const struct node *core;
 	const struct node *packages;
 	const struct node *core_database;
 	const struct node *packages_database;
+	const char *world;
 };
 
 static int check_manifest(struct manifest *manifest, const char *channel,
@@ -471,11 +477,25 @@ static int check_manifest(struct manifest *manifest, const char *channel,
 	const struct node *sequence = lookup(root, "sequence");
 	const struct node *architectures;
 	const struct node *host_entry;
+	const struct node *world;
 	const char *declared;
 
 	if (!schema_version || schema_version->type != NODE_INTEGER ||
-	    schema_version->integer != 1) {
+	    (schema_version->integer != 1 && schema_version->integer != 2)) {
 		*error = "unsupported manifest schema version";
+		return 0;
+	}
+	world = lookup(root, "world");
+	if (world) {
+		if (world->type != NODE_STRING || world->text[0] == '\0') {
+			*error = "manifest names an invalid world";
+			return 0;
+		}
+		manifest->world = world->text;
+	} else if (schema_version->integer == 1) {
+		manifest->world = DEFAULT_WORLD;
+	} else {
+		*error = "manifest names no world";
 		return 0;
 	}
 	declared = string_of(root, "channel");
@@ -668,6 +688,10 @@ static int command_field(const struct manifest *manifest, const char *field)
 		const struct node *sequence = lookup(manifest->root, "sequence");
 
 		printf("%llu\n", sequence->integer);
+		return 0;
+	}
+	if (strcmp(field, "world") == 0) {
+		printf("%s\n", manifest->world);
 		return 0;
 	}
 	if (strcmp(field, "core.database.name") == 0) {

--- a/src/vdpm-channel.c
+++ b/src/vdpm-channel.c
@@ -836,9 +836,11 @@ static int command_series(const char *path)
 	for (member = channels->members; member; member = member->next) {
 		const char *status = string_of(member->value, "status");
 		const char *summary = string_of(member->value, "summary");
+		const char *world = string_of(member->value, "world");
 
-		printf("%s\t%s\t%s\n", member->key, status ? status : "unknown",
-		       summary ? summary : "");
+		printf("%s\t%s\t%s\t%s\n", member->key,
+		       status ? status : "unknown", summary ? summary : "",
+		       world ? world : DEFAULT_WORLD);
 	}
 	node_free(root);
 	return 0;

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -9,10 +9,24 @@ trap cleanup EXIT
 
 archive_root="$temporary_directory/archive/vitasdk"
 mkdir -p "$archive_root/bin/include" "$archive_root/libexec/vdpm" "$archive_root/etc"
-for executable in vdpm-channel arm-vita-eabi-gcc; do
-	printf '#!/usr/bin/env sh\nexit 0\n' > "$archive_root/bin/$executable"
-	chmod +x "$archive_root/bin/$executable"
-done
+printf '#!/usr/bin/env sh\nexit 0\n' > "$archive_root/bin/arm-vita-eabi-gcc"
+chmod +x "$archive_root/bin/arm-vita-eabi-gcc"
+# The seed's channel helper. It verifies nothing here, but it does answer
+# `series`, because a seed that could not would not be able to run
+# `vdpm channels` either -- and the bootstrap reads the index through it
+# rather than by pattern-matching JSON.
+cat > "$archive_root/bin/vdpm-channel" <<'CHANNEL'
+#!/usr/bin/env sh
+[ "$1" = series ] || exit 0
+python3 - "$2" <<'PYEOF'
+import json, sys
+index = json.load(open(sys.argv[1]))
+for name, entry in index["channels"].items():
+    print("\t".join((name, entry.get("status", "unknown"),
+                     entry.get("summary", ""), entry.get("world", "vita"))))
+PYEOF
+CHANNEL
+chmod +x "$archive_root/bin/vdpm-channel"
 printf '#!/usr/bin/env sh\nexit 0\n' > "$archive_root/libexec/vdpm/pacman"
 chmod +x "$archive_root/libexec/vdpm/pacman"
 # Records what it was asked to do, so the test can tell whether the bootstrap

--- a/tests/test-channel-manifest.sh
+++ b/tests/test-channel-manifest.sh
@@ -134,7 +134,7 @@ reject_replaced 'escape sequence in a string' '"release":"r"' '"release":"\u0072
 
 # --- schema and value constraints ------------------------------------------
 
-reject_replaced 'unsupported schema version' '"schema_version":1' '"schema_version":2'
+reject_replaced 'unsupported schema version' '"schema_version":1' '"schema_version":3'
 reject_replaced 'zero channel sequence' '"sequence":7' '"sequence":0'
 reject_replaced 'short database digest' "$packages_digest" 'abc'
 reject_replaced 'uppercase database digest' "$packages_digest" "$(printf 'A%.0s' {1..64})"
@@ -184,6 +184,33 @@ if "$tool" verify "$manifest" "$signature" "$temporary_root/rsa-public.pem" >/de
 	printf 'non-Ed25519 public key was unexpectedly accepted\n' >&2
 	exit 1
 fi
+
+# --- worlds -----------------------------------------------------------------
+
+# A version 1 manifest predates worlds, so one that does not name a world can
+# only have meant the world that existed then. A version 2 manifest has to say,
+# which is what stops an old client from installing a second world as the first.
+world_file="$temporary_root/world.json"
+world_of() {
+	"$tool" field "$1" nightly "$host" world
+}
+
+printf '%s\n' "$minimal" > "$world_file"
+test "$(world_of "$world_file")" = vita
+
+named=${minimal%\}},\"world\":\"vita_softfp\"}
+printf '%s\n' "$named" > "$world_file"
+expect_accepted "$world_file"
+test "$(world_of "$world_file")" = vita_softfp
+
+two=${named/\"schema_version\":1/\"schema_version\":2}
+printf '%s\n' "$two" > "$world_file"
+expect_accepted "$world_file"
+test "$(world_of "$world_file")" = vita_softfp
+
+reject_replaced 'version 2 without a world' '"schema_version":1' '"schema_version":2'
+reject_replaced 'empty world' '"sequence":7' '"sequence":7,"world":""'
+reject_replaced 'world that is not a string' '"sequence":7' '"sequence":7,"world":7'
 
 # --- digests ----------------------------------------------------------------
 

--- a/tests/test-channel-worlds-listing.sh
+++ b/tests/test-channel-worlds-listing.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# What `vdpm channels` prints, on both installers, for an index that names
+# more than one world.
+#
+# The column appears only when there is a second world, so the listing
+# everybody reads today does not grow a column whose every row says the only
+# answer there is. The two installers have to agree on that, byte for byte:
+# a difference here is a Windows user reading a different truth.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-worlds-listing.XXXXXXXX")
+command -v pwsh >/dev/null 2>&1 || { printf 'pwsh is not installed\n' >&2; exit 77; }
+
+tool="$temporary_root/vdpm-channel"
+# shellcheck disable=SC2046
+"${CC:-cc}" -std=c99 -o "$tool" "$repository_root/src/vdpm-channel.c" \
+	$(pkg-config --cflags libcrypto 2>/dev/null) \
+	$(pkg-config --libs libcrypto 2>/dev/null || printf -- '-lcrypto')
+
+openssl genpkey -algorithm ed25519 -out "$temporary_root/key.pem" 2>/dev/null
+openssl pkey -in "$temporary_root/key.pem" -pubout \
+	-out "$temporary_root/key-public.pem" 2>/dev/null
+
+write_index() {
+	printf '%s\n' "$2" > "$1"
+	openssl pkeyutl -sign -rawin -inkey "$temporary_root/key.pem" \
+		-out "$1.sig" -in "$1" 2>/dev/null
+}
+
+one='{"channels":{"2026.08":{"status":"supported","summary":"Most homebrew.","world":"vita"},"nightly":{"status":"development","summary":"Moves under you.","world":"vita"}},"schema_version":1}'
+two='{"channels":{"2026.08":{"status":"supported","summary":"Most homebrew.","world":"vita"},"nightly":{"status":"development","summary":"Moves under you.","world":"vita"},"nightly-softfp":{"status":"development","summary":"Soft-float ABI.","world":"vita_softfp"}},"schema_version":1}'
+
+served="$temporary_root/served"
+mkdir -p "$served"
+
+# PowerShell fetches with Invoke-WebRequest, which has no file:// scheme, so
+# both installers read the same index over the same local server.
+python3 - "$served" "$temporary_root/port" <<'PYEOF' &
+import http.server, functools, sys
+directory, port_file = sys.argv[1], sys.argv[2]
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *arguments):
+        pass
+handler = functools.partial(Quiet, directory=directory)
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+with open(port_file, "w") as handle:
+    handle.write(str(server.server_address[1]))
+server.serve_forever()
+PYEOF
+server_pid=$!
+cleanup() { kill "$server_pid" 2>/dev/null || true; rm -rf -- "$temporary_root"; }
+trap cleanup EXIT
+
+for _ in {1..50}; do
+	[[ -s $temporary_root/port ]] && break
+	sleep 0.1
+done
+[[ -s $temporary_root/port ]] || { printf 'the test server did not start\n' >&2; exit 1; }
+base="http://127.0.0.1:$(cat "$temporary_root/port")"
+
+run_shell() {
+	local root=$1
+	VITASDK="$root" VITASDK_CHANNEL_BASE_URL="$base" \
+		bash "$repository_root/include/list-channels.sh"
+}
+
+run_powershell() {
+	local root=$1
+	VITASDK="$root" VITASDK_CHANNEL_BASE_URL="$base" \
+		pwsh -NoProfile -File "$repository_root/include/list-channels.ps1"
+}
+
+compare() {
+	local label=$1 document=$2 expect_column=$3
+	rm -f -- "$served"/index.json*
+	write_index "$served/index.json" "$document"
+
+	local sh_root="$temporary_root/$label-sh" ps_root="$temporary_root/$label-ps"
+	for root in "$sh_root" "$ps_root"; do
+		rm -rf -- "$root"
+		# The shell installer looks in bin/, the Windows one under the
+		# msys tree its bootstrap creates. Both get the same binary.
+		mkdir -p "$root/bin" "$root/share/vdpm/msys/usr/bin"
+		cp "$tool" "$root/bin/vdpm-channel"
+		cp "$tool" "$root/share/vdpm/msys/usr/bin/vdpm-channel.exe"
+		cp "$temporary_root/key-public.pem" "$root/share/vdpm/channel-public-key.pem"
+	done
+
+	run_shell "$sh_root" > "$temporary_root/$label.sh.out"
+	run_powershell "$ps_root" > "$temporary_root/$label.ps.out"
+
+	if ! diff -u "$temporary_root/$label.sh.out" "$temporary_root/$label.ps.out"; then
+		printf 'the two installers disagree for %s\n' "$label" >&2
+		exit 1
+	fi
+
+	if [[ $expect_column == yes ]]; then
+		grep -q 'WORLD' "$temporary_root/$label.sh.out" || {
+			printf 'no world column with two worlds:\n' >&2
+			cat "$temporary_root/$label.sh.out" >&2
+			exit 1
+		}
+		grep -q 'vita_softfp' "$temporary_root/$label.sh.out" || {
+			printf 'the second world is not shown\n' >&2
+			exit 1
+		}
+	else
+		if grep -q 'WORLD' "$temporary_root/$label.sh.out"; then
+			printf 'a world column appeared with only one world:\n' >&2
+			cat "$temporary_root/$label.sh.out" >&2
+			exit 1
+		fi
+		# The summary must be the summary, with nothing appended to it.
+		grep -qx ' nightly       development    Moves under you.' \
+			"$temporary_root/$label.sh.out" || {
+			printf 'the summary column is not what the index says:\n' >&2
+			cat -A "$temporary_root/$label.sh.out" >&2
+			exit 1
+		}
+	fi
+}
+
+compare one-world "$one" no
+compare two-worlds "$two" yes
+
+printf 'channel world listing contract tests passed\n'

--- a/tests/test-refresh-worlds.sh
+++ b/tests/test-refresh-worlds.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# What refresh writes into pacman.conf comes from the manifest it verified.
+#
+# It used to say vita in three places -- the Architecture line, the repository
+# section and the database file name -- which was right while one world
+# existed. A second world's packages carry a different arch, and pacman
+# refuses a package whose arch the configuration does not list, so a wrong
+# line here is an installation that cannot install anything.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-refresh-worlds.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_root"; }
+trap cleanup EXIT
+
+source "$repository_root/include/host-triplet.sh"
+host=$(vdpm_host_triplet) || { printf 'unsupported test host\n' >&2; exit 77; }
+
+tool="$temporary_root/vdpm-channel"
+# shellcheck disable=SC2046
+"${CC:-cc}" -std=c99 -o "$tool" "$repository_root/src/vdpm-channel.c" \
+	$(pkg-config --cflags libcrypto 2>/dev/null) \
+	$(pkg-config --libs libcrypto 2>/dev/null || printf -- '-lcrypto')
+
+openssl genpkey -algorithm ed25519 -out "$temporary_root/key.pem" 2>/dev/null
+openssl pkey -in "$temporary_root/key.pem" -pubout \
+	-out "$temporary_root/key-public.pem" 2>/dev/null
+
+assets="$temporary_root/assets"
+mkdir -p "$assets"
+printf 'core database\n' > "$assets/$host.db"
+
+digest_of() { "$tool" sha256 "$1"; }
+
+# Writes a signed manifest for one world and returns the path.
+manifest_for() {
+	local world=$1 database=$2 out="$temporary_root/$1.json"
+
+	printf 'packages database for %s\n' "$world" > "$assets/$database"
+	printf '%s\n' "{\"channel\":\"nightly\",\"core\":{\"architectures\":{\"$host\":{\"database\":{\"name\":\"$host.db\",\"sha256\":\"$(digest_of "$assets/$host.db")\"}}},\"release\":\"sdk-1\",\"repository\":\"vitasdk/autobuilds\"},\"packages\":{\"database\":{\"name\":\"$database\",\"sha256\":\"$(digest_of "$assets/$database")\"},\"release\":\"packages-1\",\"repository\":\"vitasdk/vitasdk-autobuild\"},\"schema_version\":2,\"sequence\":7,\"world\":\"$world\"}" > "$out"
+	openssl pkeyutl -sign -rawin -inkey "$temporary_root/key.pem" \
+		-out "$out.sig" -in "$out" 2>/dev/null
+	printf '%s\n' "$out"
+}
+
+refresh_into() {
+	local root=$1 manifest=$2
+
+	mkdir -p "$root/share/vdpm"
+	VITASDK="$root" \
+	VITASDK_CHANNEL_PUBLIC_KEY="$temporary_root/key-public.pem" \
+	VITASDK_CHANNEL_MANIFEST="$manifest" \
+	VITASDK_CHANNEL_ASSET_DIRECTORY="$assets" \
+	VDPM_CHANNEL_TOOL="$tool" \
+		bash "$repository_root/include/refresh-repositories.sh" nightly
+}
+
+hard=$(manifest_for vita vita.db)
+soft=$(manifest_for vita_softfp vita_softfp.db)
+
+# --- a second world reaches the configuration unchanged ---------------------
+
+root="$temporary_root/softfp-root"
+refresh_into "$root" "$soft" >/dev/null
+
+grep -qx "Architecture = $host vita_softfp" "$root/etc/pacman.conf" || {
+	printf 'Architecture does not name the world:\n' >&2
+	sed -n '1,6p' "$root/etc/pacman.conf" >&2
+	exit 1
+}
+grep -qx '\[vita_softfp\]' "$root/etc/pacman.conf" || {
+	printf 'repository section does not name the world\n' >&2
+	exit 1
+}
+grep -q '\[vita\]' "$root/etc/pacman.conf" && {
+	printf 'the first world leaked into a second world configuration\n' >&2
+	exit 1
+}
+[[ -f $root/var/lib/pacman/sync/vita_softfp.db ]] || {
+	printf 'the database was not stored under the name the manifest gives\n' >&2
+	ls "$root/var/lib/pacman/sync" >&2
+	exit 1
+}
+
+# --- the first world still works ---------------------------------------------
+
+root="$temporary_root/hard-root"
+refresh_into "$root" "$hard" >/dev/null
+grep -qx "Architecture = $host vita" "$root/etc/pacman.conf"
+grep -qx '\[vita\]' "$root/etc/pacman.conf"
+[[ -f $root/var/lib/pacman/sync/vita.db ]]
+
+# --- a root keeps the world it has -------------------------------------------
+
+if refresh_into "$root" "$soft" >/dev/null 2>"$temporary_root/refusal"; then
+	printf 'a refresh changed the world of an existing root\n' >&2
+	exit 1
+fi
+grep -q 'needs a new VITASDK root' "$temporary_root/refusal" || {
+	printf 'refused without saying why:\n' >&2
+	cat "$temporary_root/refusal" >&2
+	exit 1
+}
+# The refusal must not have touched what was there.
+grep -qx "Architecture = $host vita" "$root/etc/pacman.conf" || {
+	printf 'the refused refresh rewrote the configuration anyway\n' >&2
+	exit 1
+}
+
+printf 'refresh world contract tests passed\n'

--- a/tests/test-series-autoselection.sh
+++ b/tests/test-series-autoselection.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Which series an installer picks when nobody names one.
+#
+# A world decides the ABI of everything the toolchain compiles, so it is never
+# picked for somebody. Two worlds cut a series in the same month, so the names
+# differ only by a suffix -- 2026.11 and 2026.11-softfp -- and neither sort
+# order can tell them apart on merit: the shell sorts YYYY.MM numerically and
+# ties, PowerShell sorts the whole name as text and the longer one wins. Both
+# had to filter by world instead, and both are checked here against the same
+# index.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vdpm-autoselect.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_root"; }
+trap cleanup EXIT
+
+tool="$temporary_root/vdpm-channel"
+# shellcheck disable=SC2046
+"${CC:-cc}" -std=c99 -o "$tool" "$repository_root/src/vdpm-channel.c" \
+	$(pkg-config --cflags libcrypto 2>/dev/null) \
+	$(pkg-config --libs libcrypto 2>/dev/null || printf -- '-lcrypto')
+
+# Keys go in canonical order, so 2026.11-softfp cannot be placed first to
+# bait a reader that takes what comes first. It does not need to be: sorting
+# the names descending as text puts the longer one on top wherever it sits.
+index="$temporary_root/index.json"
+printf '%s\n' '{"channels":{"2026.08":{"status":"supported","summary":"Older.","world":"vita"},"2026.11":{"status":"supported","summary":"Most homebrew.","world":"vita"},"2026.11-softfp":{"status":"supported","summary":"Soft-float ABI.","world":"vita_softfp"},"nightly":{"status":"development","summary":"Moves.","world":"vita"}},"schema_version":1}' > "$index"
+
+default_world=vita
+
+# --- the shell installer ------------------------------------------------------
+
+# The selection as bootstrap-vitasdk.sh performs it, read out of the script so
+# the two cannot drift apart silently.
+selection=$(sed -n '/series "\$index" |/,/head -n1)/p' \
+	"$repository_root/bootstrap-vitasdk.sh")
+[[ -n $selection ]] || {
+	printf 'the selection in bootstrap-vitasdk.sh no longer matches this test\n' >&2
+	exit 1
+}
+staging_directory=$temporary_root
+channel_tool=$(basename "$tool")
+DEFAULT_WORLD=$default_world
+export DEFAULT_WORLD
+channel=""
+eval "$selection"
+shell_choice=$channel
+
+[[ $shell_choice == 2026.11 ]] || {
+	printf 'the shell installer chose %s, not 2026.11\n' "$shell_choice" >&2
+	exit 1
+}
+
+# --- the Windows installer ----------------------------------------------------
+
+if command -v pwsh >/dev/null 2>&1; then
+	windows_choice=$(pwsh -NoProfile -Command "
+		\$DefaultWorld = '$default_world'
+		\$index = Get-Content '$index' -Raw | ConvertFrom-Json
+		\$index.channels.PSObject.Properties |
+			Where-Object {
+				\$_.Value.status -eq 'supported' -and
+				(\$(if (\$_.Value.PSObject.Properties['world']) {
+					\$_.Value.world } else { \$DefaultWorld })) -eq \$DefaultWorld
+			} |
+			Sort-Object -Property Name -Descending |
+			Select-Object -First 1 -ExpandProperty Name")
+	[[ $windows_choice == 2026.11 ]] || {
+		printf 'the Windows installer chose %s, not 2026.11\n' "$windows_choice" >&2
+		exit 1
+	}
+	# The two installers must agree, which is the whole point of checking both.
+	[[ $windows_choice == "$shell_choice" ]] || {
+		printf 'the installers disagree: %s and %s\n' \
+			"$shell_choice" "$windows_choice" >&2
+		exit 1
+	}
+else
+	printf 'pwsh is not installed: the Windows half was not checked\n' >&2
+fi
+
+# --- an index with no series for the default world ----------------------------
+
+printf '%s\n' '{"channels":{"2026.11-softfp":{"status":"supported","summary":"Only world.","world":"vita_softfp"}},"schema_version":1}' > "$index"
+channel=""
+eval "$selection"
+empty=$channel
+[[ -z $empty ]] || {
+	printf 'a series of another world was chosen: %s\n' "$empty" >&2
+	exit 1
+}
+
+printf 'series autoselection contract tests passed\n'


### PR DESCRIPTION
Fase 4 of the softfp plan: the client stops assuming the world it installs.

The manifest has carried a `world` since before this and nothing read it — zero hits for it under `include/` and `src/`. Four things follow from that.

## refresh wrote `vita` in three places

The `Architecture` line, the repository section and the database file name. pacman refuses a package whose arch the configuration does not list, so those three lines are the difference between an installation that works and one that can install nothing. They come from the verified manifest now, and the repository name is the database name without its suffix rather than a second assumption.

## A version 1 manifest does not have to say which world it is

`2026.08` does not carry one — only `nightly` does. A version 1 manifest predates worlds and can only have meant the world that existed then, so it defaults; version 2 has to say. That is what earns the bump: it is not new data, it is the ability to require it, which version 1 cannot be given retroactively. An old client refuses a version 2 manifest outright instead of installing a second world as the first.

## A root keeps the world it has

Changing it would leave a sysroot of one ABI with a package database of another, which pacman cannot tell apart by file name. Refresh refuses and says a new root is what is needed.

## Nobody is given a world they did not ask for

Two worlds cut a series in the same month, so the names differ only by a suffix and neither installer could tell them apart on merit — the shell sorts `YYYY.MM` numerically and ties, PowerShell sorts the whole name as text and the longer one simply wins:

```
$ # PowerShell, on an index with 2026.11 and 2026.11-softfp, before this
sin filtro  -> 2026.11-softfp
```

Both filter to the default world now. Asking for one by name is unaffected: this runs only when nobody did.

The shell installer reads the index through the helper rather than matching JSON by pattern. That helper is the *seed's* and may predate worlds, so one that prints no world is read as printing the default — no series of a second world is marked supported before the seed pinned here can tell them apart. The bootstrap test's fake helper was `exit 0`, which no real seed is; it answers `series` now.

## Tests

Three new ones, each verified to fail against the code as it stands today:

| | |
|---|---|
| `test-refresh-worlds.sh` | drives the real refresh script offline, both worlds, plus the refusal |
| `test-channel-worlds-listing.sh` | the two installers' `channels` output, compared byte for byte |
| `test-series-autoselection.sh` | what each installer picks from an index with both series |

The listing test caught a bug it was written for: the Windows installer split each row into three fields, so the fourth arrived appended to the summary after a tab.

The `WORLD` column appears only when the index names more than one — a column whose every row says the only answer there is is not information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)