### PR TITLE
Pin the tree's seed at v0.1.6

### DIFF
--- a/bootstrap-vitasdk.ps1
+++ b/bootstrap-vitasdk.ps1
@@ -22,8 +22,8 @@ if (Test-Path $InstallDirectory) {
 # script the root instead of them; that is a deliberate choice. The key digest
 # below is checked anyway, because it catches a seed that brings a different
 # channel key.
-$SeedRelease = 'v0.1.5'
-$SeedVersion = '0.1.5'
+$SeedRelease = 'v0.1.6'
+$SeedVersion = '0.1.6'
 $ChannelKeySha256 = 'c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307'
 # The world somebody gets when they do not ask for one. A world decides the
 # ABI of everything the toolchain compiles, so it is never picked for them.

--- a/bootstrap-vitasdk.sh
+++ b/bootstrap-vitasdk.sh
@@ -28,8 +28,8 @@ EOF
 #
 # What the network is never allowed to decide is which verifier to trust: the
 # manifest that says what to install is checked with the key already on disk.
-SEED_RELEASE=v0.1.5
-SEED_VERSION=0.1.5
+SEED_RELEASE=v0.1.6
+SEED_VERSION=0.1.6
 CHANNEL_KEY_SHA256=c02df2e12216f6f633d94206634bbe8f244d74f610b29e922d7ea8bab2efb307
 # The world somebody gets when they do not ask for one. A world decides the
 # ABI of everything the toolchain compiles, so it is never picked for them.


### PR DESCRIPTION
v0.1.6 is published, so it is what a git checkout should seed from. The release bundles already seed from themselves; this is the tree catching up.

It matters slightly more than the last one of these. v0.1.6 is the first seed whose `vdpm-channel` prints which world a channel is for, and the series resolution in this script reads exactly that. Until this pin moves, a checkout resolves the series through a helper that cannot say, which the script handles — it reads a missing world as the default — but the pin is what makes it read a real answer instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)